### PR TITLE
Use tfenv to manage terraform to support runtime flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ ENV PATH="/root/.tfenv/bin:${PATH}"
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
     echo 'PATH=/root/.tfenv/bin:${PATH}' >> ~/.bashrc && \
     source ~/.bashrc && \
-    tfenv install ${TERRAFORM_VERSION}
+    tfenv install ${TERRAFORM_VERSION} && \
+    tfenv use ${TERRAFORM_VERSION}
 
 # pip installs
 COPY awscli.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,23 @@ LABEL VERSION=${VERSION}
 
 # apk adds
 ARG ANSIBLE_VERSION="2.9.9-r0"
-ARG TERRAFORM_VERSION="0.12.25-r0"
-RUN apk add --no-cache ansible=${ANSIBLE_VERSION} \
-                       terraform=${TERRAFORM_VERSION} && \
-    apk add --no-cache --update jq \
+RUN apk add --no-cache ansible=${ANSIBLE_VERSION} && \
+    apk add --no-cache --update bash \
+                                curl \
+                                git \
+                                jq \
+                                perl-utils \
                                 python3 \
                                 py3-pip \
                                 yarn
+
+# git installs
+ARG TERRAFORM_VERSION="0.12.26"
+ENV PATH="/root/.tfenv/bin:${PATH}"
+RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
+    echo 'PATH=/root/.tfenv/bin:${PATH}' >> ~/.bashrc && \
+    source ~/.bashrc && \
+    tfenv install ${TERRAFORM_VERSION}
 
 # pip installs
 COPY awscli.txt .
@@ -33,6 +43,11 @@ ARG MERMAID_CLI_VERSION="8.5.1-2"
 ENV PATH="/node_modules/.bin/:${PATH}"
 RUN yarn add mermaid@${MERMAID_VERSION} \
              @mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION}
+
+# cleanup
+RUN apk del git && \
+    rm -rf /var/cache/apk/* \
+           /tmp/*
 
 COPY entrypoint.sh .
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,17 @@ COMMIT_HASH       := $(shell git rev-parse HEAD)
 FROM_IMAGE         = alpine
 FROM_IMAGE_TAG     = 3
 IMAGE_NAME         = easy_infra
-APK_PACKAGES       = ansible terraform
+APK_PACKAGES       = ansible
 YARN_PACKAGES      = mermaid @mermaid-js/mermaid-cli
 UNAME_S           := $(shell uname -s)
-VERSION            = 0.2.1
+VERSION            = 0.3.0
 
 
 ## Validation
 ifneq ($(UNAME_S),Darwin)
 $(error This project currently only supports Darwin)
 endif
+
 ifndef COMMIT_HASH
 $(error COMMIT_HASH was not properly set)
 endif
@@ -23,28 +24,44 @@ endif
 build:
 	@DOCKER_BUILDKIT=1 docker build --rm -t $(IMAGE_NAME):latest -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):$(COMMIT_HASH) --build-arg "FROM_IMAGE=$(FROM_IMAGE)" --build-arg "FROM_IMAGE_TAG=$(FROM_IMAGE_TAG)" .
 
+
 .PHONY: update
-update:
-	@echo "Updating the apk package versions in the Dockerfile..."
+update: update-apk update-awscli update-terraform update-yarn
+
+.PHONY: update-apk
+update-apk:
+	@echo "Updating the apk package versions..."
 	@for package in $(APK_PACKAGES); do \
-		version=$$(docker run --rm $(FROM_IMAGE):$(FROM_IMAGE_TAG) /bin/ash -c "apk update &>/dev/null; apk add --no-cache $${package} &>/dev/null; echo \$$(apk search -x $${package} | sed 's/^$${package}-//g')"); \
+		version=$$(docker run --rm easy_infra:latest "apk update &>/dev/null && apk search -x $${package} | sed 's/^$${package}-//g'"); \
 		./update.sh --package=$${package} --version=$${version}; \
 	done
 	@echo "Done!"
-	@echo "Updating the yarn package versions in the Dockerfile..."
+
+.PHONY: update-awscli
+update-awscli: awscli-to-freeze.txt
+	@echo "Updating the awscli.txt..."
+	@docker run --rm -v $$(pwd):/usr/src/app/ python:3 /bin/bash -c "pip3 install -r /usr/src/app/awscli-to-freeze.txt &>/dev/null && pip3 freeze > /usr/src/app/awscli.txt"
+	@echo "Done!"
+
+.PHONY: update-terraform
+update-terraform:
+	@echo "Updating the terraform version..."
+	@version=$$(docker run --rm easy_infra:latest "tfenv list-remote 2>/dev/null | egrep -v '(rc|beta)' | head -1"); \
+		./update.sh --package=terraform --version=$${version}
+	@echo "Done!"
+
+.PHONY: update-yarn
+update-yarn:
+	@echo "Updating the yarn package versions..."
 	@for package in $(YARN_PACKAGES); do\
-		version=$$(docker run --rm $(FROM_IMAGE):$(FROM_IMAGE_TAG) /bin/ash -c "apk update &>/dev/null; apk add --no-cache yarn jq &>/dev/null; yarn info $${package} --json | jq -r .data[\\\"dist-tags\\\"].latest"); \
+		version=$$(docker run --rm easy_infra:latest "yarn info $${package} --json 2>/dev/null | jq -r .data[\\\"dist-tags\\\"].latest"); \
 		./update.sh --package=$${package} --version=$${version}; \
 	done
 	@echo "Done!"
+
 
 .PHONY: push_tag
 push_tag:
 	@git tag v$(VERSION)
 	@git push origin v$(VERSION)
-
-.PHONY: awscli
-awscli: awscli-to-freeze.txt
-	@python3 -c 'print("Updating the awscli.txt file...")'
-	@docker run --rm -v $$(pwd):/usr/src/app/ python:3.8 /bin/bash -c "pip3 install -r /usr/src/app/awscli-to-freeze.txt && pip3 freeze > /usr/src/app/awscli.txt"
 

--- a/awscli.txt
+++ b/awscli.txt
@@ -1,5 +1,5 @@
-awscli==1.18.71
-botocore==1.16.21
+awscli==1.18.72
+botocore==1.16.22
 colorama==0.4.3
 docutils==0.15.2
 jmespath==0.10.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,19 +3,15 @@
 set -u # nounset
 set -o pipefail
 
-# Print the ansible version
-ansible --version
-
-# Print the awscli version
-aws --version
-
-# Print the terraform version
-terraform version
-
-# Run the CMD, otherwise open an ash shell
 if [ $# -eq 0 ]; then
+  # Print select pakage versions then open an ash shell
+  ansible --version
+  aws --version
+  terraform version
+
   /usr/bin/env ash
 else
-  $@
+  # Run the CMD
+  eval "$@"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 if [ $# -eq 0 ]; then
   # Print select pakage versions then open an ash shell
-  ansible --version
+  ansible --version | head -1
   aws --version
   terraform version
 


### PR DESCRIPTION
# Contributor Comments
Moves to using `tfenv` to install and manage Terraform versions instead of using the apk package.  This allows runtime use of `tfenv`, such as `tfenv install` and `tfenv use`.

## Pull Request Checklist
Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)