### PR TITLE
Output details when security tool exits non-zero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -L https://github.com/liamg/tfsec/releases/download/${TFSEC_VERSION}/tf
     chmod 0755 /usr/local/bin/tfsec
 
 # git installs
-ARG TERRAFORM_VERSION="0.12.28"
+ARG TERRAFORM_VERSION="0.12.29"
 ARG TFENV_VERSION="v2.0.0"
 ENV PATH="/root/.tfenv/bin:${PATH}"
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
@@ -57,8 +57,8 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
     tfenv use ${TERRAFORM_VERSION}
 
 # yarn adds
-ARG MERMAID_VERSION="8.6.0"
-ARG MERMAID_CLI_VERSION="8.6.0"
+ARG MERMAID_VERSION="8.6.4"
+ARG MERMAID_CLI_VERSION="8.6.4"
 ENV PATH="/node_modules/.bin/:${PATH}"
 RUN yarn add mermaid@${MERMAID_VERSION} \
              @mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ FUNCTION_GENERATOR = "terraform" "tfsec" "\/" "recursive scan"
 GITHUB             = tfutils/tfenv liamg/tfsec
 IMAGE_NAME         = easy_infra
 UNAME_S           := $(shell uname -s)
-VERSION            = 0.4.3
+VERSION            = 0.4.4
 YARN_PACKAGES      = mermaid @mermaid-js/mermaid-cli
 
 

--- a/awscli.txt
+++ b/awscli.txt
@@ -1,5 +1,5 @@
-awscli==1.18.98
-botocore==1.17.21
+awscli==1.18.110
+botocore==1.17.33
 colorama==0.4.3
 docutils==0.15.2
 jmespath==0.10.0
@@ -9,4 +9,4 @@ PyYAML==5.3.1
 rsa==4.5
 s3transfer==0.3.3
 six==1.15.0
-urllib3==1.25.9
+urllib3==1.25.10

--- a/functions
+++ b/functions
@@ -64,10 +64,11 @@ function terraform() {
     _feedback INFO "Skipping tfsec because it was already run on $(date -d @$(cat /tfsec_complete))"
   # Otherwise, run the security scan
   else
-    tfsec / &>/dev/null
+    tfsec / &>/tfsec_output
     process_security_tool_exit_status "${?}" "tfsec" "recursive scan"
     return=${?}
     if [[ ${return:-1} != 0 ]]; then
+      cat /tfsec_output
       return ${return}
     fi
   fi

--- a/functions_template
+++ b/functions_template
@@ -16,10 +16,11 @@ function %FUNCTION_NAME%() {
     _feedback INFO "Skipping %SECURITY_TOOL% because it was already run on $(date -d @$(cat /%SECURITY_TOOL%_complete))"
   # Otherwise, run the security scan
   else
-    %SECURITY_TOOL% %SECURITY_TOOL_ARGS% &>/dev/null
+    %SECURITY_TOOL% %SECURITY_TOOL_ARGS% &>/%SECURITY_TOOL%_output
     process_security_tool_exit_status "${?}" "%SECURITY_TOOL%" "%SECURITY_TOOL_ACTION%"
     return=${?}
     if [[ ${return:-1} != 0 ]]; then
+      cat /%SECURITY_TOOL%_output
       return ${return}
     fi
   fi


### PR DESCRIPTION
# Contributor Comments
Previously when a security tool like `tfsec` failed, the details were suppressed, making it more difficult to remediate the issue.  This write the output to disk and prints it to stdout if the exit status of the security tool is non-zero.

This also updates all of the `easy_infra` components.

## Pull Request Checklist
Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)