### PR TITLE
Update packages including Terraform 0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL VERSION="${VERSION}"
 
 # apt-get installs
 ARG ANSIBLE_VERSION="2.9.6+dfsg-1"
-ARG AZURE_CLI_VERSION="2.10.0-1~focal"
+ARG AZURE_CLI_VERSION="2.10.1-1~focal"
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
@@ -43,7 +43,7 @@ RUN apt-get update \
  && rm -rf /var/cache/apt/archives/*
 
 # binary downloads
-ARG TFSEC_VERSION="v0.24.1"
+ARG TFSEC_VERSION="v0.25.0"
 ARG PACKER_VERSION="v1.6.1"
 RUN curl -L https://github.com/liamg/tfsec/releases/download/${TFSEC_VERSION}/tfsec-linux-amd64 -o /usr/local/bin/tfsec \
  && chmod 0755 /usr/local/bin/tfsec \
@@ -52,7 +52,7 @@ RUN curl -L https://github.com/liamg/tfsec/releases/download/${TFSEC_VERSION}/tf
  && chmod 0755 /usr/local/bin/packer
 
 # git installs
-ARG TERRAFORM_VERSION="0.12.29"
+ARG TERRAFORM_VERSION="0.13.0"
 ARG TFENV_VERSION="v2.0.0"
 ENV PATH="/root/.tfenv/bin:${PATH}"
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
@@ -64,8 +64,8 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && tfenv use ${TERRAFORM_VERSION}
 
 # yarn adds
-ARG MERMAID_VERSION="8.6.4"
-ARG MERMAID_CLI_VERSION="8.6.4"
+ARG MERMAID_VERSION="8.7.0"
+ARG MERMAID_CLI_VERSION="8.7.0"
 ENV PATH="/node_modules/.bin/:${PATH}"
 RUN yarn add mermaid@${MERMAID_VERSION} \
              @mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ FUNCTION_GENERATOR = "terraform" "tfsec" "\/" "recursive scan"
 GITHUB             = tfutils/tfenv liamg/tfsec hashicorp/packer
 IMAGE_NAME         = easy_infra
 UNAME_S           := $(shell uname -s)
-VERSION            = 0.4.7
+VERSION            = 0.5.0
 YARN_PACKAGES      = mermaid @mermaid-js/mermaid-cli
 
 

--- a/awscli.txt
+++ b/awscli.txt
@@ -1,5 +1,5 @@
-awscli==1.18.113
-botocore==1.17.36
+awscli==1.18.116
+botocore==1.17.39
 colorama==0.4.3
 docutils==0.15.2
 jmespath==0.10.0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ $# -eq 0 ]; then
   # Print select tool versions then open an bash shell
   echo -en "aws-cli\t\t" && command aws --version | awk -F' ' '{print $1}' | awk -F'/' '{print $2}'
   echo -en "azure-cli\t" && command az version | jq -r '.["azure-cli"]'
-  echo -en "terraform\t" && command terraform version | awk -F' ' '{print $2}' | sed 's/^v//'
+  echo -en "terraform\t" && command terraform version | head -1 | awk -F' ' '{print $2}' | sed 's/^v//'
   echo -en "packer\t\t"  && command packer --version
   echo -en "ansible\t\t" && command ansible --version | head -1 | awk -F' ' '{print $2}'
 


### PR DESCRIPTION
# Contributor Comments
Update packages including Terraform 0.13, which recently [went GA](https://www.hashicorp.com/blog/announcing-hashicorp-terraform-0-13/).  It's still possible to run an older version of terraform in this release by running:
```
docker run -e tf_version="0.12.29" easy_infra:latest 'tfenv install ${tf_version} && tfenv use ${tf_version} && terraform version'
```

## Pull Request Checklist
Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)