### PR TITLE
Remove mermaid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ RUN apt-get update \
                                                python3-pip \
                                                unzip \
                                                yarn \
-                                               # For mermaid-cli \
-                                               gconf-service libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxss1 libxtst6 libappindicator1 libnss3 libasound2 libatk1.0-0 libc6 ca-certificates fonts-liberation lsb-release xdg-utils wget libxcb-dri3-0 libdrm2 libgbm1 \
  && apt-get clean autoclean \
  && apt-get -y autoremove \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
@@ -68,16 +66,6 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && git checkout ${TFENV_VERSION} \
  && tfenv install ${TERRAFORM_VERSION} \
  && tfenv use ${TERRAFORM_VERSION}
-
-# yarn adds
-ARG MERMAID_VERSION="8.8.2"
-ARG MERMAID_CLI_VERSION="8.8.1"
-ENV PATH="/node_modules/.bin/:${PATH}"
-RUN yarn add mermaid@${MERMAID_VERSION} \
-             @mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION} \
- && yarn cache clean
-# Mermaid-specific setup
-COPY puppeteer-config.json /usr/local/etc/puppeteer-config.json
 
 # pip installs
 COPY awscli.txt .

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ GITHUB             = tfutils/tfenv tfsec/tfsec hashicorp/packer
 IMAGE_NAME         = easy_infra
 UNAME_S           := $(shell uname -s)
 VERSION            = 0.7.1
-YARN_PACKAGES      = mermaid @mermaid-js/mermaid-cli
 
 
 ## Validation
@@ -34,7 +33,7 @@ all: update build
 update: update-dependencies update-functions
 
 .PHONY: update-dependencies
-update-dependencies: update-apt update-requirements update-awscli update-github update-terraform update-yarn
+update-dependencies: update-apt update-requirements update-awscli update-github update-terraform
 
 
 .PHONY: update-functions
@@ -82,15 +81,6 @@ update-terraform:
 	@echo "Updating the terraform version..."
 	@version=$$(docker run --rm easy_infra:latest /bin/bash -c "tfenv list-remote 2>/dev/null | egrep -v '(rc|alpha|beta)' | head -1"); \
 		$(call update_dockerfile_package,terraform,$${version})
-	@echo "Done!"
-
-.PHONY: update-yarn
-update-yarn:
-	@echo "Updating the yarn package versions..."
-	@for package in $(YARN_PACKAGES); do\
-		version=$$(docker run --rm easy_infra:latest /bin/bash -c "yarn info $${package} --json 2>/dev/null | jq -r .data[\\\"dist-tags\\\"].latest"); \
-		$(call update_dockerfile_package,$${package},$${version}); \
-	done
 	@echo "Done!"
 
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ While it's not suggested, if you'd like to disable this behavior you have some o
     docker run -v $(pwd):/iac seiso/easy_infra /bin/bash -c "terraform --skip-tfsec init && terraform --skip-tfsec validate && terraform --skip-tfsec apply"
     ```
 
-## Mermaid-cli
-As an interim workaround for `mermaid-cli` (aka `mmdc`), you can specify a puppeteer config which disables sandboxing, for instance:
-```bash
-docker run -v $(pwd):/iac seiso/easy_infra mmdc -p /usr/local/etc/puppeteer-config.json -i file.mmd
-```
-
 ## Contributing
 1. [Fork the repository](https://github.com/SeisoLLC/easy_infra/fork)
 1. Create a feature branch via `git checkout -b feature/description`

--- a/puppeteer-config.json
+++ b/puppeteer-config.json
@@ -1,3 +1,0 @@
-{
-  "args": ["--no-sandbox"]
-}


### PR DESCRIPTION
# Contributor Comments
Initially we had bundled mermaid into easy_infra because at Seiso we
feel strongly that documentation should be tightly coupled with your
code and/or configuration, and when possible, be automatically
generated. However, this caused significant image bloat and we decided
to remove it for the time being, and in the future we may release a
separate documentation generation image to fulfill this use case.

## Pull Request Checklist
Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)