### PR TITLE
Add terraform plugin caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Ignore terraform.d, including the plugin cache
-terraform.d
+# Ignore .terraform.d, including the plugin cache
+.terraform.d
 
 # Created by https://www.toptal.com/developers/gitignore/api/vim,macos,python,terraform
 # Edit at https://www.toptal.com/developers/gitignore?templates=vim,macos,python,terraform

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+# Ignore terraform.d, including the plugin cache
+terraform.d
 
-# Created by https://www.toptal.com/developers/gitignore/api/macos,vim,python
-# Edit at https://www.toptal.com/developers/gitignore?templates=macos,vim,python
+# Created by https://www.toptal.com/developers/gitignore/api/vim,macos,python,terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim,macos,python,terraform
 
 ### macOS ###
 # General
@@ -171,6 +173,36 @@ dmypy.json
 # profiling data
 .prof
 
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]
@@ -192,4 +224,4 @@ tags
 # Persistent undo
 [._]*.un~
 
-# End of https://www.toptal.com/developers/gitignore/api/macos,vim,python
+# End of https://www.toptal.com/developers/gitignore/api/vim,macos,python,terraform

--- a/.terraformrc
+++ b/.terraformrc
@@ -1,3 +1,2 @@
 plugin_cache_dir   = "$HOME/.terraform.d/plugin-cache"
-disable_checkpoint = true
 

--- a/.terraformrc
+++ b/.terraformrc
@@ -1,0 +1,3 @@
+plugin_cache_dir   = "$HOME/.terraform.d/plugin-cache"
+disable_checkpoint = true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN curl -L https://github.com/liamg/tfsec/releases/download/${TFSEC_VERSION}/tf
 # git installs
 ARG TERRAFORM_VERSION="0.13.4"
 ARG TFENV_VERSION="v2.0.0"
+COPY .terraformrc .
 ENV PATH="/root/.tfenv/bin:${PATH}"
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && echo 'PATH=/root/.tfenv/bin:${PATH}' >> ~/.bashrc \
@@ -65,7 +66,9 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && cd ~/.tfenv \
  && git checkout ${TFENV_VERSION} \
  && tfenv install ${TERRAFORM_VERSION} \
- && tfenv use ${TERRAFORM_VERSION}
+ && tfenv use ${TERRAFORM_VERSION} \
+ && rm -rf ~/.tfenv/.git \
+ && mkdir ~/.terraform.d/plugin-cache
 
 # pip installs
 COPY awscli.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN curl -L https://github.com/liamg/tfsec/releases/download/${TFSEC_VERSION}/tf
 # git installs
 ARG TERRAFORM_VERSION="0.13.4"
 ARG TFENV_VERSION="v2.0.0"
-COPY .terraformrc .
+COPY .terraformrc /root/
 ENV PATH="/root/.tfenv/bin:${PATH}"
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && echo 'PATH=/root/.tfenv/bin:${PATH}' >> ~/.bashrc \
@@ -69,7 +69,7 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && tfenv install ${TERRAFORM_VERSION} \
  && tfenv use ${TERRAFORM_VERSION} \
  && rm -rf ~/.tfenv/.git \
- && mkdir ~/.terraform.d/plugin-cache
+ && mkdir -p ~/.terraform.d/plugin-cache
 
 # pip installs
 COPY awscli.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
                                                python3-pip \
                                                unzip \
                                                yarn \
+                                               time \
  && apt-get clean autoclean \
  && apt-get -y autoremove \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv \
  && tfenv install ${TERRAFORM_VERSION} \
  && tfenv use ${TERRAFORM_VERSION} \
  && rm -rf ~/.tfenv/.git \
- && mkdir -p ~/.terraform.d/plugin-cache
+ && mkdir -p ~/.terraform.d/plugin-cache \
+ && command terraform -install-autocomplete
 
 # pip installs
 COPY awscli.txt .

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ While it's not suggested, if you'd like to disable this behavior you have some o
     docker run -v $(pwd):/iac seiso/easy_infra /bin/bash -c "terraform --skip-tfsec init && terraform --skip-tfsec validate && terraform --skip-tfsec apply"
     ```
 
+## Improve Caching
+If you're working with the same terraform across multiple runs you can leverage the cache via the following:
+```
+docker run -v $(pwd):/iac -v $(pwd)/plugin-cache:/root/.terraform.d/plugin-cache easy_infra:latest /bin/bash -c "terraform init; terraform version"
+```
+
 ## Contributing
 1. [Fork the repository](https://github.com/SeisoLLC/easy_infra/fork)
 1. Create a feature branch via `git checkout -b feature/description`


### PR DESCRIPTION
# Contributor Comments
Add terraform plugin caching.  Branch name is misleading (but true)

To check the timing of various activities, consider:
```
docker run -e DISABLE_SECURITY=true -w /iac -v $(pwd)/main.tf:/iac/main.tf easy_infra:latest time -p /bin/bash -c "terraform init; terraform init; terraform init; terraform init; terraform init"
```

## Pull Request Checklist
Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)