### PR TITLE
Fix environment variable defaults

### DIFF
--- a/functions.j2
+++ b/functions.j2
@@ -92,12 +92,13 @@ function {{ command }}() {
   fi
 
   ## Setup the per-tool security integrations
-{# For each command being wrapped, loop through each security tool and make tool-specific skips via env var/argument -#}
+{#- For each command being wrapped, loop through each security tool and make tool-specific skips via env var/argument #}
   {%- for tool in commands[command]["security"] %}
   {{ tool }}_upper=$(echo "{{ tool }}" | tr '[:lower:]' '[:upper:]')
   {{ tool }}_argument="--skip-{{ tool }}"
   {# In order for us to use ${variable} in bash directly around a jinja2 variable it needs to be escaped -#}
   {{ tool }}_env_var="SKIP_{{ '${' }}{{ tool }}_upper}"
+  declare "SKIP_{{ '${' }}{{ tool }}_upper}={{ '${' }}!{{ tool }}_env_var:-false}"
 
   ## Methods to skip {{ tool }}
   # If the "skip" argument was provided, skip the security scan


### PR DESCRIPTION
# Contributor Comments
Previously the logic of `"${!{{ tool }}_env_var,,}" == "true"` was causing an error when run non-interactively:
```bash
$ docker run --rm easy_infra:latest terraform validate
INFO:  Passed terraform init initialization
INFO:  Passed terraform validate validation
/functions: line 114: !tfsec_env_var: unbound variable
```

This was not an issue when run interactively:
```bash
$ docker run --rm -it easy_infra:latest
...
# terraform validate
INFO:  Passed terraform init initialization
INFO:  Passed terraform validate validation
INFO:  Passed tfsec recursive scan
INFO:  Passed checkov checkov directory scan
Success! The configuration is valid.
```

## Testing
Test the `SKIP_*` environment variables.  Example:
```bash
docker run --rm -e SKIP_CHECKOV=true easy_infra:latest /bin/bash -c "terraform version && terraform --skip-tfsec validate && terraform validate"
```

## Pull Request Checklist
Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
 - [X] Ensure that `make build` completes successfully
 - [X] Rebase your branch against the latest commit of the target branch, which likely should be `master`
 - [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)