### PR TITLE
Add helpers to maintain trivy and reformat code

### DIFF
--- a/easy_infra/constants.py
+++ b/easy_infra/constants.py
@@ -34,5 +34,8 @@ GITHUB_REPOS_RELEASES = {
 GITHUB_REPOS_TAGS = {"aws/aws-cli"}
 PYTHON_PACKAGES = {"checkov"}
 HASHICORP_PROJECTS = {"terraform", "packer"}
+# The following line is touchy, see easy_infra/util.py's
+# update_container_security_scanner function
+CONTAINER_SECURITY_SCANNER = "aquasec/trivy:0.18.3"
 UNACCEPTABLE_VULNS = ["CRITICAL"]
 INFORMATIONAL_VULNS = ["UNKNOWN", "LOW", "MEDIUM", "HIGH"]

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from logging import getLogger
 from pathlib import Path
@@ -71,6 +72,7 @@ def get_latest_release_from_apt(*, package: str) -> str:
         image=image,
         auto_remove=True,
         detach=False,
+        user=0,
         command='/bin/bash -c "apt-get update &>/dev/null && apt-cache policy '
         + package
         + " | grep '^  Candidate:' | awk -F' ' '{print $NF}'\"",
@@ -116,6 +118,34 @@ def update_config_file(*, thing: str, version: str):
     config = parse_config(config_file=constants.CONFIG_FILE)
     config["commands"][thing]["version"] = version
     write_config(config=config)
+
+
+def update_test_security_scanner(
+    *, image: str, tag: str, file_name: str = "tests/test.py"
+) -> None:
+    """Update the security scanner used in tests"""
+    file_object = Path(file_name)
+    pattern = re.compile(fr'^.+scanner = "{image}:.+"$\n')
+    final_content = []
+
+    # Validate
+    if not file_object.is_file():
+        LOG.error("%s is not a valid file", file_name)
+        sys.exit(1)
+
+    # Extract
+    with open(file_object) as file:
+        file_contents = file.readlines()
+
+    # Transform
+    for line in file_contents:
+        if pattern.fullmatch(line):
+            line = f'    scanner = "{image}:{tag}"\n'
+        final_content.append(line)
+
+    # Load
+    with open(file_object, "w") as file:
+        file.writelines(final_content)
 
 
 def opinionated_docker_run(

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -120,12 +120,12 @@ def update_config_file(*, thing: str, version: str):
     write_config(config=config)
 
 
-def update_test_security_scanner(
-    *, image: str, tag: str, file_name: str = "tests/test.py"
+def update_container_security_scanner(
+    *, image: str, tag: str, file_name: str = "easy_infra/constants.py"
 ) -> None:
     """Update the security scanner used in tests"""
     file_object = Path(file_name)
-    pattern = re.compile(fr'^.+scanner = "{image}:.+"$\n')
+    pattern = re.compile(fr'^CONTAINER_SECURITY_SCANNER = "{image}:.+"$\n')
     final_content = []
 
     # Validate
@@ -140,7 +140,7 @@ def update_test_security_scanner(
     # Transform
     for line in file_contents:
         if pattern.fullmatch(line):
-            line = f'    scanner = "{image}:{tag}"\n'
+            line = f'CONTAINER_SECURITY_SCANNER = "{image}:{tag}"\n'
         final_content.append(line)
 
     # Load

--- a/tasks.py
+++ b/tasks.py
@@ -108,7 +108,7 @@ def update(_c, debug=False):
     # On github they use aquasecurity but on docker hub it's aquasec, and the
     # github releases are prefaced with v but not on docker hub
     version = utils.get_latest_release_from_github(repo="aquasecurity/trivy").lstrip('v')
-    utils.update_test_security_scanner(image="aquasec/trivy", tag=version)
+    utils.update_container_security_scanner(image="aquasec/trivy", tag=version)
 
     # Update the CI dependencies
     image = "python:3.9"

--- a/tasks.py
+++ b/tasks.py
@@ -107,7 +107,9 @@ def update(_c, debug=False):
 
     # On github they use aquasecurity but on docker hub it's aquasec, and the
     # github releases are prefaced with v but not on docker hub
-    version = utils.get_latest_release_from_github(repo="aquasecurity/trivy").lstrip('v')
+    version = utils.get_latest_release_from_github(repo="aquasecurity/trivy").lstrip(
+        "v"
+    )
     utils.update_container_security_scanner(image="aquasec/trivy", tag=version)
 
     # Update the CI dependencies

--- a/tasks.py
+++ b/tasks.py
@@ -193,18 +193,7 @@ def lint(_c, debug=False):
         volumes=volumes,
         working_dir=working_dir,
     )
-
-    response = container.wait(condition="not-running")
-    decoded_response = container.logs().decode("utf-8")
-    response["logs"] = decoded_response.strip().replace("\n", "  ")
-    container.remove()
-    if not response["StatusCode"] == 0:
-        LOG.error(
-            "Received a non-zero status code from docker (%s); additional details: %s",
-            response["StatusCode"],
-            response["logs"],
-        )
-        sys.exit(response["StatusCode"])
+    process_container(container=container)
 
     LOG.info("Linting completed successfully")
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -954,9 +954,7 @@ def run_security(*, image: str):
     volumes = {temp_dir: {"bind": working_dir, "mode": "ro"}}
 
     num_tests_ran = 0
-    # The following line is touchy, see easy_infra/util.py's
-    # update_test_security_scanner function
-    scanner = "aquasec/trivy:0.18.3"
+    scanner = constants.CONTAINER_SECURITY_SCANNER
 
     # Provide debug information about unknown, low, and medium severity
     # findings

--- a/tests/test.py
+++ b/tests/test.py
@@ -954,6 +954,8 @@ def run_security(*, image: str):
     volumes = {temp_dir: {"bind": working_dir, "mode": "ro"}}
 
     num_tests_ran = 0
+    # The following line is touchy, see easy_infra/util.py's
+    # update_test_security_scanner function
     scanner = "aquasec/trivy:0.18.3"
 
     # Provide debug information about unknown, low, and medium severity


### PR DESCRIPTION
# Contributor Comments

This adds helper functions/tasks to maintain trivy (`pipenv run invoke update` now pulls the latest `trivy` version and injects it into the tests) and reformats code with `pipenv run invoke update` in a way that ensures it is in line with the `goat`.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)