### PR TITLE
Add checkov and tfsec customizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV SKIP_KICS="false"
 ARG TERRAFORM_VERSION
 ARG TFENV_VERSION
 ENV AUTODETECT="false"
-ENV KICS_QUERIES_PATH="/home/easy_infra/.kics/assets/queries"
+ENV KICS_INCLUDE_QUERIES_PATH="/home/easy_infra/.kics/assets/queries"
 ENV KICS_LIBRARY_PATH="/home/easy_infra/.kics/assets/libraries"
 ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 ENV PATH="/home/easy_infra/.local/bin:${PATH}"

--- a/docs/Ansible/index.rst
+++ b/docs/Ansible/index.rst
@@ -33,14 +33,14 @@ Customizing KICS
 +-----------------------------+----------------------------------------------+-------------------------------------------------------------------------------+
 | Environment variable        | Result                                       | Example                                                                       |
 +=============================+==============================================+===============================================================================+
-| ``KICS_QUERIES``            | Passes the value to ``--include-queries``    | ``c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d,7dfb316c-a6c2-454d-b8a2-97f147b0c0ff`` |
+| ``KICS_INCLUDE_QUERIES``    | Passes the value to ``--include-queries``    | ``c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d,7dfb316c-a6c2-454d-b8a2-97f147b0c0ff`` |
 +-----------------------------+----------------------------------------------+-------------------------------------------------------------------------------+
 | ``KICS_EXCLUDE_SEVERITIES`` | Passes the value to ``--exclude-severities`` | ``info,low``                                                                  |
 +-----------------------------+----------------------------------------------+-------------------------------------------------------------------------------+
 
 ::
 
-    KICS_QUERIES=c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d,7dfb316c-a6c2-454d-b8a2-97f147b0c0ff
+    KICS_INCLUDE_QUERIES=c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d,7dfb316c-a6c2-454d-b8a2-97f147b0c0ff
     KICS_EXCLUDE_SEVERITIES=info,low
     docker run --env-file <(env | grep ^KICS_) -v $(pwd):/iac easy_infra:latest-minimal ansible-playbook EXAMPLE.yml --check
 

--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -44,7 +44,7 @@ Customizing KICS
 +-----------------------------+----------------------------------------------+-------------------------------------------------------------------------------+
 | Environment variable        | Result                                       | Example                                                                       |
 +=============================+==============================================+===============================================================================+
-| ``KICS_QUERIES``            | Passes the value to ``--include-queries``    | ``4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73`` |
+| ``KICS_INCLUDE_QUERIES``    | Passes the value to ``--include-queries``    | ``4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73`` |
 +-----------------------------+----------------------------------------------+-------------------------------------------------------------------------------+
 | ``KICS_EXCLUDE_SEVERITIES`` | Passes the value to ``--exclude-severities`` | ``info,low``                                                                  |
 +-----------------------------+----------------------------------------------+-------------------------------------------------------------------------------+
@@ -52,7 +52,7 @@ Customizing KICS
 
 ::
 
-    KICS_QUERIES=4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73
+    KICS_INCLUDE_QUERIES=4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73
     KICS_EXCLUDE_SEVERITIES=info,low
     docker run --env-file <(env | grep ^KICS_) -v $(pwd):/iac easy_infra:latest-minimal terraform validate
 

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -3,15 +3,18 @@ _anchors:
   - tf
   security: &id002
     checkov:
-      command: checkov -d . --no-guide
+      command: checkov -d . --download-external-modules True --no-guide
+      customizations:
+        CHECKOV_EXTERNAL_CHECKS_DIR: --external-checks-dir
+        CHECKOV_SKIP_CHECK: --skip-check
       description: directory scan
     kics:
-      command: kics scan --type Terraform --no-progress --queries-path ${KICS_QUERIES_PATH}
+      command: kics scan --type Terraform --no-progress --queries-path ${KICS_INCLUDE_QUERIES_PATH}
         --libraries-path ${KICS_LIBRARY_PATH} --report-formats json --output-path
         ${KICS_JSON_REPORT_PATH} --output-name kics --path .
       customizations:
         KICS_EXCLUDE_SEVERITIES: --exclude-severities
-        KICS_QUERIES: --include-queries
+        KICS_INCLUDE_QUERIES: --include-queries
       description: directory scan
     terrascan:
       command: terrascan scan -i terraform -t all -d .
@@ -19,6 +22,8 @@ _anchors:
     tfsec:
       command: tfsec .
       description: recursive scan
+      customizations:
+        TFSEC_DISABLE_CHECKS: -e
   validation: &id003
   - command: terraform init -backend=false
     description: initialization
@@ -31,12 +36,12 @@ commands:
     - ansible-playbook
     security:
       kics:
-        command: kics scan --type Ansible --no-progress --queries-path ${KICS_QUERIES_PATH}
+        command: kics scan --type Ansible --no-progress --queries-path ${KICS_INCLUDE_QUERIES_PATH}
           --libraries-path ${KICS_LIBRARY_PATH} --report-formats json --output-path
           ${KICS_REPORTS} --output-name kics --path .
         customizations:
           KICS_EXCLUDE_SEVERITIES: --exclude-severities
-          KICS_QUERIES: --include-queries
+          KICS_INCLUDE_QUERIES: --include-queries
         description: directory scan
     version: 2.9.6+dfsg-1
     version_argument: --version

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -21,9 +21,9 @@ _anchors:
       description: recursive scan
     tfsec:
       command: tfsec .
-      description: recursive scan
       customizations:
         TFSEC_DISABLE_CHECKS: -e
+      description: recursive scan
   validation: &id003
   - command: terraform init -backend=false
     description: initialization

--- a/tests/test.py
+++ b/tests/test.py
@@ -435,7 +435,7 @@ def run_terraform(*, image: str, final: bool = False):
         #     commands are passed through bash
         (
             {
-                "KICS_INCLUDE_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73",  # Purposefully doesn't apply to kics_volumes
+                "KICS_INCLUDE_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73",  # Doesn't apply to kics_volumes
                 "DISABLE_SECURITY": "true",
             },
             "terraform init",

--- a/tests/test.py
+++ b/tests/test.py
@@ -356,7 +356,7 @@ def run_terraform(*, image: str, final: bool = False):
         ),
         (
             {
-                "KICS_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73"
+                "KICS_INCLUDE_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73"
             },
             "terraform init",
             0,
@@ -435,7 +435,7 @@ def run_terraform(*, image: str, final: bool = False):
         #     commands are passed through bash
         (
             {
-                "KICS_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73",  # Purposefully doesn't apply to kics_volumes
+                "KICS_INCLUDE_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73",  # Purposefully doesn't apply to kics_volumes
                 "DISABLE_SECURITY": "true",
             },
             "terraform init",
@@ -443,7 +443,7 @@ def run_terraform(*, image: str, final: bool = False):
         ),
         (
             {
-                "KICS_QUERIES": "5a2486aa-facf-477d-a5c1-b010789459ce",  # Would normally fail due to kics_volumes
+                "KICS_INCLUDE_QUERIES": "5a2486aa-facf-477d-a5c1-b010789459ce",  # Would normally fail due to kics_volumes
                 "DISABLE_SECURITY": "true",
             },
             "terraform init",
@@ -507,7 +507,7 @@ def run_terraform(*, image: str, final: bool = False):
                 "SKIP_CHECKOV": "true",
                 "SKIP_TFSEC": "true",
                 "SKIP_TERRASCAN": "true",
-                "KICS_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73",
+                "KICS_INCLUDE_QUERIES": "4728cd65-a20c-49da-8b31-9c08b423e4db,46883ce1-dc3e-4b17-9195-c6a601624c73",
             },
             "terraform validate",
             0,
@@ -517,14 +517,14 @@ def run_terraform(*, image: str, final: bool = False):
                 "SKIP_CHECKOV": "true",
                 "SKIP_TFSEC": "true",
                 "SKIP_TERRASCAN": "true",
-                "KICS_QUERIES": "5a2486aa-facf-477d-a5c1-b010789459ce",
+                "KICS_INCLUDE_QUERIES": "5a2486aa-facf-477d-a5c1-b010789459ce",
             },
             "terraform validate",
             50,
         ),
         (
             {},
-            '/usr/bin/env bash -c "KICS_QUERIES=5a2486aa-facf-477d-a5c1-b010789459ce terraform --skip-tfsec --skip-terrascan --skip-checkov validate"',
+            '/usr/bin/env bash -c "KICS_INCLUDE_QUERIES=5a2486aa-facf-477d-a5c1-b010789459ce terraform --skip-tfsec --skip-terrascan --skip-checkov validate"',
             50,
         ),
         (
@@ -941,18 +941,18 @@ def run_ansible(*, image: str):
             4,
         ),  # Exits 4 because insecure.yml is not a valid Play
         (
-            {"KICS_QUERIES": "c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d"},
+            {"KICS_INCLUDE_QUERIES": "c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d"},
             "ansible-playbook insecure.yml --check",
             4,
         ),  # Exits with 4 because insecure.yml is not a valid Play, and the provided insecure playbook does not apply to the included queries
         (
-            {"KICS_QUERIES": "7dfb316c-a6c2-454d-b8a2-97f147b0c0ff"},
+            {"KICS_INCLUDE_QUERIES": "7dfb316c-a6c2-454d-b8a2-97f147b0c0ff"},
             "ansible-playbook insecure.yml --check",
             50,
         ),
         (
             {},
-            '/usr/bin/env bash -c "KICS_QUERIES=7dfb316c-a6c2-454d-b8a2-97f147b0c0ff ansible-playbook insecure.yml --check"',
+            '/usr/bin/env bash -c "KICS_INCLUDE_QUERIES=7dfb316c-a6c2-454d-b8a2-97f147b0c0ff ansible-playbook insecure.yml --check"',
             50,
         ),
         (


### PR DESCRIPTION
# Contributor Comments

This just adds the ability to set certain checkov and tfsec customizations by passing environment variables into `easy_infra` at runtime.

This intentionally does not have specific tests; there are tests of the base generated code of mapping env vars into runtime arguments, which I'm considering sufficient for this, as we are not doing e2e testing of each component's possible matrix of options.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)