### PR TITLE
fix(docs): bump m2r2 to 0.3.2 which adds mistune pinning

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@
 # This file defines requirements used by readthedocs.io
 #
 
-m2r2 == 0.2.7
+m2r2 == 0.3.2
 sphinx_rtd_theme == 0.5.2


### PR DESCRIPTION
# Contributor Comments

Our read the docs integration has been failing with the below error when it attempts to run `/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/bin/python -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html`.  It is likely due to the version of `m2r2` which we had installed, which did not pin the version of `mistune` that it was using.  As of `m2r2` `0.3.2`, [`mistune` is now pinned](https://github.com/CrossNox/m2r2/blob/development/CHANGES.md#version-032-2021-12-10) and the docs appear to be [building successfully now](https://readthedocs.org/projects/easy-infra/builds/15532777/).

```bash
Running Sphinx v4.3.1
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 279, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 237, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 394, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 429, in load_extension
    mod = import_module(extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/site-packages/m2r2.py", line 82, in <module>
    class RestBlockGrammar(mistune.BlockGrammar):
AttributeError: module 'mistune' has no attribute 'BlockGrammar'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/easy-infra/envs/latest/lib/python3.7/site-packages/m2r2.py", line 82, in <module>
    class RestBlockGrammar(mistune.BlockGrammar):
AttributeError: module 'mistune' has no attribute 'BlockGrammar'
The full traceback has been saved in /tmp/sphinx-err-donjkmqw.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)