### PR TITLE
Add Checkov baseline support and true up docs

### DIFF
--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -2,41 +2,56 @@
 Terraform
 *********
 
-`Terraform <https://github.com/hashicorp/terraform>`_ enables you to safely and
-predictably create, change, and improve infrastructure.
+`Terraform <https://github.com/hashicorp/terraform>`_ enables you to safely and predictably create, change, and improve infrastructure.
 
-The ``easy_infra`` project includes and secures Terraform as a component due to
-its popularity and versitility in provisioning and updating environments as
-Infrastructure as Code (IaC).
+The ``easy_infra`` project includes and secures Terraform as a component due to its popularity and versitility in provisioning and updating
+environments as Infrastructure as Code (IaC).
 
-``easy_infra``'s Terraform security uses tools such as `KICS
-<https://kics.io/>`_, `Checkov <https://www.checkov.io/>`_, `tfsec
-<https://tfsec.dev/>`_, and `Terrascan
-<https://www.accurics.com/products/terrascan/>`_ to semi-transparently assess
-the provided IaC against the defined security policy.
+``easy_infra``'s Terraform security uses tools such as `KICS <https://kics.io/>`_, `Checkov <https://www.checkov.io/>`_, `tfsec
+<https://tfsec.dev/>`_, and `Terrascan <https://www.accurics.com/products/terrascan/>`_ to semi-transparently assess the provided IaC against the
+defined security policy.
 
-Varying levels of Terraform security are included in the ``easy_infra`` tags,
-including minimal, aws, az, and latest.  For more information, see
+Varying levels of Terraform security are included in the ``easy_infra`` tags, including minimal, aws, az, and latest.  For more information, see
 `Disabling Security`_ below.
 
 .. note::
-    In the minimal, aws, and az images, only the KICS and Checkov security tools are
-    available.  All other security tools will be skipped.
+    In the minimal, aws, and az images, only the KICS and Checkov security tools are available.  All other security tools will be skipped.
 
 
 Use Cases
 ---------
 
-If you use Software Version Control (such as ``git``) to manage your Terraform
-IaC, consider executing ``terraform validate`` with easy_infra as a pipeline
-action on commit or pull request::
+If you use Software Version Control (such as ``git``) to manage your Terraform IaC, consider executing ``terraform validate`` with easy_infra as a
+pipeline action on commit or pull request::
 
     docker run -v $(pwd):/iac seiso/easy_infra:latest-minimal terraform validate
 
-You can also use easy_infra to deploy your infrastructure using ``terraform
-plan`` and ``terraform deploy``::
+You can also use easy_infra to deploy your infrastructure using ``terraform plan`` and ``terraform deploy``::
 
     docker run -v $(pwd):/iac seiso/easy_infra:latest-minimal /bin/bash -c "terraform plan && terraform apply -auto-approve"
+
+
+Customizing Checkov
+^^^^^^^^^^^^^^^^^^^
+
++---------------------------------+-----------------------------------------------+----------------------------+
+| Environment Variable            | Result                                        | Example                    |
++=================================+===============================================+============================+
+| ``CHECKOV_BASELINE``            | Passes the value to ``--baseline``            | ``/iac/.checkov.baseline`` |
++---------------------------------+-----------------------------------------------+----------------------------+
+| ``CHECKOV_EXTERNAL_CHECKS_DIR`` | Passes the value to ``--external-checks-dir`` | ``/iac/checkov_rules/``    |
++---------------------------------+-----------------------------------------------+----------------------------+
+| ``CHECKOV_SKIP_CHECK``          | Passes the value to ``--skip-check``          | ``CKV_AWS_20``             |
++---------------------------------+-----------------------------------------------+----------------------------+
+
+
+::
+
+    CHECKOV_BASELINE=/iac/.checkov.baseline
+    CHECKOV_EXTERNAL_CHECKS_DIR=/iac/checkov_rules/
+    CHECKOV_SKIP_CHECK=CKV_AWS_20
+    docker run --env-file <(env | grep ^CHECKOV_) -v $(pwd):/iac easy_infra:latest-minimal terraform validate
+
 
 Customizing KICS
 ^^^^^^^^^^^^^^^^
@@ -56,6 +71,23 @@ Customizing KICS
     KICS_EXCLUDE_SEVERITIES=info,low
     docker run --env-file <(env | grep ^KICS_) -v $(pwd):/iac easy_infra:latest-minimal terraform validate
 
+
+Customizing tfsec
+^^^^^^^^^^^^^^^^^
+
++--------------------------+----------------------------+----------------------------+
+| Environment Variable     | Result                     | Example                    |
++==========================+============================+============================+
+| ``TFSEC_DISABLE_CHECKS`` | Passes the value to ``-e`` | ``log-group-customer-key`` |
++--------------------------+----------------------------+----------------------------+
+
+
+::
+
+    TFSEC_DISABLE_CHECKS=log-group-customer-key
+    docker run --env-file <(env | grep ^TFSEC_) -v $(pwd):/iac easy_infra:latest terraform validate
+
+
 Terraform Caching
 ^^^^^^^^^^^^^^^^^
 
@@ -63,6 +95,7 @@ If you're working with the same terraform code across multiple runs, you can
 leverage the cache::
 
     docker run -v $(pwd):/iac -v $(pwd)/plugin-cache:/home/easy_infra/.terraform.d/plugin-cache easy_infra:latest-minimal /bin/bash -c "terraform init; terraform validate"
+
 
 Disabling Security
 ^^^^^^^^^^^^^^^^^^
@@ -99,19 +132,15 @@ The injected security tooling can be disabled entirely or individually, using
 +------------------------+------------------------------+-------------------------------------------+
 
 .. note::
-    All command-line arguments in the above table are processed by easy_infra
-    and removed prior to passing parameters to Terraform commands.
+    All command-line arguments in the above table are processed by easy_infra and removed prior to passing parameters to Terraform commands.
 
 
 Autodetecting files
 ^^^^^^^^^^^^^^^^^^^
 
-If you'd like to autodetect where your Terraform files exist and run the
-provided command in each of those detected folders, this is the feature for
-you.  This is useful in cases where there is a single repository containing
-folders which store varying terraform files, and you would like to run a
-command (or series of commands) on all of them without needing to maintain a
-method of looping through them yourself.
+If you'd like to autodetect where your Terraform files exist and run the provided command in each of those detected folders, this is the feature for
+you.  This is useful in cases where there is a single repository containing folders which store varying terraform files, and you would like to run a
+command (or series of commands) on all of them without needing to maintain a method of looping through them yourself.
 
 +----------------------+-----------+--------------------------------------------------------------------+
 | Environment variable | Default   | Result                                                             |
@@ -126,10 +155,8 @@ method of looping through them yourself.
 Resources
 ---------
 
-Configuring custom checks can be done by leveragin the robust Rego language,
-maintained by the, Open Policy Agent (OPA) offers useful resources for cloud
-native infrastructure administrators.  Their example Terraform workflow is
-available `here  <https://www.openpolicyagent.org/docs/latest/terraform/>`_.
+Configuring custom checks can be done by leveragin the robust Rego language, maintained by the, Open Policy Agent (OPA) offers useful resources for
+cloud native infrastructure administrators.  Their example Terraform workflow is available `here
+<https://www.openpolicyagent.org/docs/latest/terraform/>`_.
 
-OPA also hosts `The Rego Playground <https://play.openpolicyagent.org/>`_ for
-testing custom Terrascan rules.
+OPA also hosts `The Rego Playground <https://play.openpolicyagent.org/>`_ for testing custom Terrascan rules.

--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -7,15 +7,15 @@ Terraform
 The ``easy_infra`` project includes and secures Terraform as a component due to its popularity and versitility in provisioning and updating
 environments as Infrastructure as Code (IaC).
 
-``easy_infra``'s Terraform security uses tools such as `KICS <https://kics.io/>`_, `Checkov <https://www.checkov.io/>`_, `tfsec
-<https://tfsec.dev/>`_, and `Terrascan <https://www.accurics.com/products/terrascan/>`_ to semi-transparently assess the provided IaC against the
-defined security policy.
+``easy_infra``'s Terraform security uses tools such as `Checkov <https://www.checkov.io/>`_, `KICS <https://kics.io/>`_, `Terrascan
+<https://www.accurics.com/products/terrascan/>`_, and `tfsec <https://tfsec.dev/>`_, to semi-transparently assess the provided IaC against the defined
+security policy.
 
 Varying levels of Terraform security are included in the ``easy_infra`` tags, including minimal, aws, az, and latest.  For more information, see
 `Disabling Security`_ below.
 
 .. note::
-    In the minimal, aws, and az images, only the KICS and Checkov security tools are available.  All other security tools will be skipped.
+    In the minimal, aws, and az images, only the Checkov and KICS security tools are available.  All other security tools will be skipped.
 
 
 Use Cases

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -5,6 +5,7 @@ _anchors:
     checkov:
       command: checkov -d . --download-external-modules True --no-guide
       customizations:
+        CHECKOV_BASELINE: --baseline
         CHECKOV_EXTERNAL_CHECKS_DIR: --external-checks-dir
         CHECKOV_SKIP_CHECK: --skip-check
       description: directory scan

--- a/tests/test.py
+++ b/tests/test.py
@@ -511,7 +511,8 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform validate",
             0,
-        ),  # Exits with 0 because the provided insecure terraform does not apply to the included kics queries. This tests the "customizations" idea from easy_infra.yml and functions.j2
+        ),  # Exits with 0 because the provided insecure terraform does not apply to the included kics queries.
+        # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "SKIP_CHECKOV": "true",
@@ -944,7 +945,8 @@ def run_ansible(*, image: str):
             {"KICS_INCLUDE_QUERIES": "c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d"},
             "ansible-playbook insecure.yml --check",
             4,
-        ),  # Exits with 4 because insecure.yml is not a valid Play, and the provided insecure playbook does not apply to the included queries. This tests the "customizations" idea from easy_infra.yml and functions.j2
+        ),  # Exits with 4 because insecure.yml is not a valid Play, and the provided insecure playbook does not apply to the included queries.
+        # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {"KICS_INCLUDE_QUERIES": "7dfb316c-a6c2-454d-b8a2-97f147b0c0ff"},
             "ansible-playbook insecure.yml --check",
@@ -961,19 +963,22 @@ def run_ansible(*, image: str):
             },
             "ansible-playbook insecure.yml --check",
             50,
-        ),  # Doesn't exclude high or medium. This tests the "customizations" idea from easy_infra.yml and functions.j2
+        ),  # Doesn't exclude high or medium.
+        # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "KICS_EXCLUDE_SEVERITIES": "high,medium",
             },
             "ansible-playbook insecure.yml --check",
             4,
-        ),  # Excludes all the relevant severities, exits 4 because insecure.yml is not a valid Play. This tests the "customizations" idea from easy_infra.yml and functions.j2
+        ),  # Excludes all the relevant severities, exits 4 because insecure.yml is not a valid Play.
+        # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {},
             '/usr/bin/env bash -c "KICS_EXCLUDE_SEVERITIES=info,low,medium,high ansible-playbook insecure.yml --check"',
             4,
-        ),  # Excludes all the severities, exits 4 because insecure.yml is not a valid Play. This tests the "customizations" idea from easy_infra.yml and functions.j2
+        ),  # Excludes all the severities, exits 4 because insecure.yml is not a valid Play.
+        # This tests the "customizations" idea from easy_infra.yml and functions.j2
     ]
 
     num_tests_ran += exec_tests(tests=tests, volumes=kics_volumes, image=image)

--- a/tests/test.py
+++ b/tests/test.py
@@ -360,12 +360,12 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform init",
             0,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {"KICS_EXCLUDE_SEVERITIES": "info"},
             "terraform validate",
             0,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
     ]
 
     LOG.debug("Testing secure terraform configurations")
@@ -440,7 +440,7 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform init",
             0,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "KICS_INCLUDE_QUERIES": "5a2486aa-facf-477d-a5c1-b010789459ce",  # Would normally fail due to kics_volumes
@@ -448,7 +448,7 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform init",
             0,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
     ]
 
     LOG.debug("Testing terraform with security disabled")
@@ -511,7 +511,7 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform validate",
             0,
-        ),  # Exits with 0 because the provided insecure terraform does not apply to the included kics queries
+        ),  # Exits with 0 because the provided insecure terraform does not apply to the included kics queries. This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "SKIP_CHECKOV": "true",
@@ -521,12 +521,12 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform validate",
             50,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {},
             '/usr/bin/env bash -c "KICS_INCLUDE_QUERIES=5a2486aa-facf-477d-a5c1-b010789459ce terraform --skip-tfsec --skip-terrascan --skip-checkov validate"',
             50,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "SKIP_CHECKOV": "true",
@@ -536,7 +536,7 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform validate",
             50,
-        ),  # Doesn't exclude high
+        ),  # Doesn't exclude high. This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "SKIP_CHECKOV": "true",
@@ -546,12 +546,12 @@ def run_terraform(*, image: str, final: bool = False):
             },
             "terraform validate",
             0,
-        ),  # Excludes all the severities
+        ),  # Excludes all the severities. This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {},
             '/usr/bin/env bash -c "KICS_EXCLUDE_SEVERITIES=info,low,medium,high terraform --skip-tfsec --skip-terrascan --skip-checkov validate"',
             0,
-        ),  # Excludes all the severities
+        ),  # Excludes all the severities. This tests the "customizations" idea from easy_infra.yml and functions.j2
     ]
 
     LOG.debug("Testing terraform with security disabled")
@@ -944,36 +944,36 @@ def run_ansible(*, image: str):
             {"KICS_INCLUDE_QUERIES": "c3b9f7b0-f5a0-49ec-9cbc-f1e346b7274d"},
             "ansible-playbook insecure.yml --check",
             4,
-        ),  # Exits with 4 because insecure.yml is not a valid Play, and the provided insecure playbook does not apply to the included queries
+        ),  # Exits with 4 because insecure.yml is not a valid Play, and the provided insecure playbook does not apply to the included queries. This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {"KICS_INCLUDE_QUERIES": "7dfb316c-a6c2-454d-b8a2-97f147b0c0ff"},
             "ansible-playbook insecure.yml --check",
             50,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {},
             '/usr/bin/env bash -c "KICS_INCLUDE_QUERIES=7dfb316c-a6c2-454d-b8a2-97f147b0c0ff ansible-playbook insecure.yml --check"',
             50,
-        ),
+        ),  # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "KICS_EXCLUDE_SEVERITIES": "info,low",
             },
             "ansible-playbook insecure.yml --check",
             50,
-        ),  # Doesn't exclude high or medium
+        ),  # Doesn't exclude high or medium. This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
                 "KICS_EXCLUDE_SEVERITIES": "high,medium",
             },
             "ansible-playbook insecure.yml --check",
             4,
-        ),  # Excludes all the relevant severities, exits 4 because insecure.yml is not a valid Play
+        ),  # Excludes all the relevant severities, exits 4 because insecure.yml is not a valid Play. This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {},
             '/usr/bin/env bash -c "KICS_EXCLUDE_SEVERITIES=info,low,medium,high ansible-playbook insecure.yml --check"',
             4,
-        ),  # Excludes all the severities, exits 4 because insecure.yml is not a valid Play
+        ),  # Excludes all the severities, exits 4 because insecure.yml is not a valid Play. This tests the "customizations" idea from easy_infra.yml and functions.j2
     ]
 
     num_tests_ran += exec_tests(tests=tests, volumes=kics_volumes, image=image)


### PR DESCRIPTION
# Contributor Comments

Add Checkov baseline support and true up docs.  Added tfsec and checkov customizations to the Terraform docs, added some comments for the intent of the tests in `tests/test.py`; no substantial additions there.  Conceptually, I have tests for customizations in `easy_infra.yml` and ensuring they are effective in `/functions`, but not planning to re-implement tests for each feature of the security tools we add support for.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)