### PR TITLE
Fix image signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
                      "latest-aws"
                      "latest-az"
                      "latest"; do
-            DIGEST=$(docker manifest inspect "seiso/easy_infra:$tag" |
-                     jq -r '.config.digest')
+            DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
+                     jq -r '.Descriptor.digest')
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
                      "latest-aws"
                      "latest-az"
                      "latest"; do
-            DIGEST=$(docker manifest inspect seiso/easy_infra:$tag |
+            DIGEST=$(docker manifest inspect "seiso/easy_infra:$tag" |
                      jq -r '.config.digest')
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,15 @@ jobs:
         run: pipenv run invoke publish latest --debug
       - name: Sign the images
         run:
-          for variant in "latest-minimal"
-                         "latest-aws"
-                         "latest-az"
-                         "latest"; do
+          for tag in "latest-minimal"
+                     "latest-aws"
+                     "latest-az"
+                     "latest"; do
+            DIGEST=$(docker manifest inspect seiso/easy_infra:$tag |
+                     jq -r '.config.digest')
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"
-              -a variant="${variant}"
-              "seiso/easy_infra@${variant}" ;
+              -a tag="${tag}"
+              "seiso/easy_infra@${DIGEST}" ;
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
                      "${TAG#v}-aws"
                      "${TAG#v}-az"
                      "${TAG#v}"; do
-            DIGEST=$(docker manifest inspect seiso/easy_infra:$tag |
+            DIGEST=$(docker manifest inspect "seiso/easy_infra:$tag" |
                      jq -r '.config.digest')
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,15 @@ jobs:
         run: pipenv run invoke publish release --debug
       - name: Sign the images
         run:
-          for variant in "${TAG#v}-minimal"
-                         "${TAG#v}-aws"
-                         "${TAG#v}-az"
-                         "${TAG#v}"; do
+          for tag in "${TAG#v}-minimal"
+                     "${TAG#v}-aws"
+                     "${TAG#v}-az"
+                     "${TAG#v}"; do
+            DIGEST=$(docker manifest inspect seiso/easy_infra:$tag |
+                     jq -r '.config.digest')
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"
-              -a variant="${variant}"
-              -a tag="${TAG}"
-              "seiso/easy_infra@${variant}" ;
+              -a tag="${tag}"
+              "seiso/easy_infra@${DIGEST}" ;
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,8 @@ jobs:
                      "${TAG#v}-aws"
                      "${TAG#v}-az"
                      "${TAG#v}"; do
-            DIGEST=$(docker manifest inspect "seiso/easy_infra:$tag" |
-                     jq -r '.config.digest')
+            DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
+                     jq -r '.Descriptor.digest')
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,10 @@ jobs:
         run: pipenv run invoke publish release --debug
       - name: Sign the images
         run:
-          for variant in "${TAG}-minimal"
-                         "${TAG}-aws"
-                         "${TAG}-az"
-                         "${TAG}"; do
+          for variant in "${TAG#v}-minimal"
+                         "${TAG#v}-aws"
+                         "${TAG#v}-az"
+                         "${TAG#v}"; do
             echo -n "${{ secrets.COSIGN_PASSWORD }}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"


### PR DESCRIPTION
# Contributor Comments

Fixes the tag of signed release images.  When the `v2021.12.02` tag is pushed, the image is `seiso/easy_infra:2021.12.02`.

Also, in order to sign tags, the digest needs to be passed to `cosign`

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)