### PR TITLE
fix(ci): Pass the cosign password as an env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,11 @@ jobs:
                      "latest"; do
             DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
                      jq -r '.Descriptor.digest') ;
-            echo -n "${{ secrets.COSIGN_PASSWORD }}" |
+            echo -n "${COSIGN_PASSWORD}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"
               -a tag="${tag}"
               "seiso/easy_infra@${DIGEST}" ;
           done
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,11 @@ jobs:
                      "${TAG#v}"; do
             DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
                      jq -r '.Descriptor.digest') ;
-            echo -n "${{ secrets.COSIGN_PASSWORD }}" |
+            echo -n "${COSIGN_PASSWORD}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"
               -a tag="${tag}"
               "seiso/easy_infra@${DIGEST}" ;
           done
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
# Contributor Comments

This passes the cosign password as an env var as documented [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)