### PR TITLE
Allow disabling updates for a component

### DIFF
--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -71,6 +71,7 @@ commands:
   kics:
     version: v1.5.1
     version_argument: version
+    allow_update: false
   packer:
     version: 1.8.0
     version_argument: version

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -69,9 +69,9 @@ commands:
     version: v1.8.13
     version_argument: --version
   kics:
+    allow_update: false
     version: v1.5.1
     version_argument: version
-    allow_update: false
   packer:
     version: 1.8.0
     version_argument: version

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -117,6 +117,11 @@ def update_config_file(*, thing: str, version: str):
 
     config = parse_config(config_file=constants.CONFIG_FILE)
     allow_update = config["commands"][thing].get("allow_update", True)
+    current_version = config["commands"][thing]["version"]
+
+    if version == current_version:
+        LOG.debug(f'No new versions have been detected for {thing}')
+        return
 
     if not allow_update:
         LOG.warning(f'Not updating {thing} to version {version} because allow_update is set to false')

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -120,15 +120,17 @@ def update_config_file(*, thing: str, version: str):
     current_version = config["commands"][thing]["version"]
 
     if version == current_version:
-        LOG.debug(f'No new versions have been detected for {thing}')
+        LOG.debug(f"No new versions have been detected for {thing}")
         return
 
     if not allow_update:
-        LOG.warning(f'Not updating {thing} to version {version} because allow_update is set to false')
+        LOG.warning(
+            f"Not updating {thing} to version {version} because allow_update is set to false"
+        )
         return
 
     config["commands"][thing]["version"] = version
-    LOG.info(f'Updating {thing} to version {version}')
+    LOG.info(f"Updating {thing} to version {version}")
     write_config(config=config)
 
 

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -116,7 +116,14 @@ def update_config_file(*, thing: str, version: str):
         version = version.decode("utf-8").rstrip()
 
     config = parse_config(config_file=constants.CONFIG_FILE)
+    allow_update = config["commands"][thing].get("allow_update", True)
+
+    if not allow_update:
+        LOG.warning(f'Not updating {thing} to version {version} because allow_update is set to false')
+        return
+
     config["commands"][thing]["version"] = version
+    LOG.info(f'Updating {thing} to version {version}')
     write_config(config=config)
 
 


### PR DESCRIPTION
# Contributor Comments

This allows you to "freeze" the version of a component by not writing the detected update to disk when you run `pipenv run invoke update`.  It also adds an optimization so the config isn't rewritten if the current version and the latest detected version are the same.

This is being added as a temporary workaround due to a decision that [KICS](https://github.com/Checkmarx/KICS) made to no longer provide binary artifacts in their GitHub releases.  See https://github.com/Checkmarx/kics/discussions/4744 and https://github.com/Checkmarx/kics/releases/tag/v1.5.1 under "Deprecation" for more details

## Testing

There are no `easy_infra` tests for `invoke update`.  Run it locally in your environment to see that packages with new releases are updated in `easy_infra.yml` and there are INFO level logs generated for those updates, and that KICS is not updated in `easy_infra.yml`, even though there is a later version available, and a log is generated describing why.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)