### PR TITLE
Update PR github action to v4, run twice a week

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
           disable_mypy: true
   test:
     name: Test
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         stage: ["minimal", "aws", "az", "final"]
@@ -64,7 +64,7 @@ jobs:
           if-no-files-found: error
   distribute:
     name: Distribute
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     needs:
       - Lint
       - Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,7 @@ name: "Update"
 
 on:
   schedule:
-    - cron: '17 3 * * *'
+    - cron: '17 4 * * 1,4'
 
 jobs:
   update:
@@ -22,7 +22,7 @@ jobs:
       - name: Update the repository
         run: pipenv run invoke update
       - name: Create or update a pull request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           title: Automated update to primary components
           commit-message: Automated update to primary components

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update:
     name: Update
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
# Contributor Comments

Update PR github action to v4, run twice a week.

Reviewed some of the [documentation here](https://github.com/peter-evans/create-pull-request/blob/0dfc93c1049996241252d9dc45a270b7c12dec6b/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs) and concluded that our best approach for running the github actions is to close/open the PR manually, and then approve/set automerge if the status checks pass.  For additional context, see the conversation in https://github.com/peter-evans/create-pull-request/issues/48

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)