### PR TITLE
Push unique tags for each commit to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Publish the latest image to Docker Hub
-        run: pipenv run invoke publish latest --stage=${{ matrix.stage }}
+      - name: Publish the images to Docker Hub
+        run: pipenv run invoke publish main --stage=${{ matrix.stage }}
       - name: Install cosign
         uses: sigstore/cosign-installer@main
       - name: Sign the image


### PR DESCRIPTION
# Contributor Comments

We are already building these tags at no additional computation expense (build once, add tags as needed - recent example [here](https://github.com/SeisoLLC/easy_infra/runs/5722007263?check_suite_focus=true#step:5:9)), but only the latest tags were being pushed in `ci.yml` for commits to main, with releases being handled exclusively in `release.yml` when a matching tag is pushed to the repo.  This change adds the release+commit tags to what's pushed to docker hub for each merge into main.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)