### PR TITLE
refactor: Unify logic for retrieving image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,18 +97,13 @@ jobs:
         run: |
           version_tag=$(pipenv run python -c "from easy_infra import constants; \
                                               print(constants.CONTEXT['${STAGE}']['buildargs']['VERSION'])")
-          latest_tag=$(pipenv run python -c "from easy_infra import constants; \
-                                             print(constants.CONTEXT['${STAGE}']['latest_tag'])")
-          tags=("${version_tag}" "${latest_tag}")
-          for tag in "${tags[@]}"; do
-            DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
-                     jq -r '.Descriptor.digest')
-            echo -n "${COSIGN_PASSWORD}" |
-            cosign sign --key cosign.key   \
-              -a git_sha="${GITHUB_SHA}"   \
-              -a tag="${tag}"              \
-              "seiso/easy_infra@${DIGEST}"
-          done
+          DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:${version_tag}" |
+                   jq -r '.Descriptor.digest')
+          echo -n "${COSIGN_PASSWORD}" |
+          cosign sign --key cosign.key   \
+            -a git_sha="${GITHUB_SHA}"   \
+            -a tag="${version_tag}"      \
+            "seiso/easy_infra@${DIGEST}"
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           STAGE: ${{ matrix.stage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,20 +94,20 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@main
       - name: Sign the image
-        run:
+        run: |
           version_tag=$(pipenv run python -c "from easy_infra import constants; \
-                                              print(constants.CONTEXT['"${STAGE}"']['buildargs']['VERSION'])") ;
+                                              print(constants.CONTEXT['${STAGE}']['buildargs']['VERSION'])")
           latest_tag=$(pipenv run python -c "from easy_infra import constants; \
-                                             print(constants.CONTEXT['"${STAGE}"']['latest_tag'])") ;
-          tags=("${version_tag}" "${latest_tag}") ;
-          for tag in ${tags[@]}; do
+                                             print(constants.CONTEXT['${STAGE}']['latest_tag'])")
+          tags=("${version_tag}" "${latest_tag}")
+          for tag in "${tags[@]}"; do
             DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
-                     jq -r '.Descriptor.digest') ;
+                     jq -r '.Descriptor.digest')
             echo -n "${COSIGN_PASSWORD}" |
-            cosign sign --key cosign.key
-              -a git_sha="${GITHUB_SHA}"
-              -a tag="${tag}"
-              "seiso/easy_infra@${DIGEST}" ;
+            cosign sign --key cosign.key   \
+              -a git_sha="${GITHUB_SHA}"   \
+              -a tag="${tag}"              \
+              "seiso/easy_infra@${DIGEST}"
           done
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"
               -a tag="${tag}"
-              "seiso/easy_infra@${DIGEST}"
+              "seiso/easy_infra@${DIGEST}" ;
           done
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,20 @@ jobs:
         uses: sigstore/cosign-installer@main
       - name: Sign the image
         run:
-          if [[ "${STAGE}" == "final" ]]; then
-            tag="latest" ;
-          else
-            tag="latest-${STAGE}" ;
-          fi ;
-          DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
-                   jq -r '.Descriptor.digest') ;
-          echo -n "${COSIGN_PASSWORD}" |
-          cosign sign --key cosign.key
-            -a git_sha="${GITHUB_SHA}"
-            -a tag="${tag}"
-            "seiso/easy_infra@${DIGEST}"
+          version_tag=$(pipenv run python -c "from easy_infra import constants; \
+                                              print(constants.CONTEXT['"${STAGE}"']['buildargs']['VERSION'])") ;
+          latest_tag=$(pipenv run python -c "from easy_infra import constants; \
+                                             print(constants.CONTEXT['"${STAGE}"']['latest_tag'])") ;
+          tags=("${version_tag}" "${latest_tag}") ;
+          for tag in ${tags[@]}; do
+            DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
+                     jq -r '.Descriptor.digest') ;
+            echo -n "${COSIGN_PASSWORD}" |
+            cosign sign --key cosign.key
+              -a git_sha="${GITHUB_SHA}"
+              -a tag="${tag}"
+              "seiso/easy_infra@${DIGEST}"
+          done
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           STAGE: ${{ matrix.stage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install the dependencies
         run: |
           python -m pip install --upgrade pipenv
-          pipenv install --dev
+          pipenv install --deploy --ignore-pipfile --dev
           mkdir "${RUNNER_TEMP}/bin"
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "${RUNNER_TEMP}/bin"
           chmod +x "${RUNNER_TEMP}/bin/syft"
@@ -81,7 +81,7 @@ jobs:
       - name: Install the dependencies
         run: |
           python -m pip install --upgrade pipenv
-          pipenv install --dev
+          pipenv install --deploy --ignore-pipfile --dev
       - name: Build the image
         run: pipenv run invoke build --stage=${{ matrix.stage }}
       - name: Log in to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install the dependencies
         run: |
           python -m pip install --upgrade pipenv
-          pipenv install --dev
+          pipenv install --deploy --ignore-pipfile --dev
           mkdir "${RUNNER_TEMP}/bin"
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "${RUNNER_TEMP}/bin"
           chmod +x "${RUNNER_TEMP}/bin/syft"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install the dependencies
         run: |
           python -m pip install --upgrade pipenv
-          pipenv install --dev
+          pipenv install --deploy --ignore-pipfile --dev
       - name: Update the repository
         run: pipenv run invoke update
       - name: Create or update a pull request

--- a/easy_infra/constants.py
+++ b/easy_infra/constants.py
@@ -3,10 +3,10 @@ easy_infra constants
 """
 
 import json
-import git
-from typing import Union
 from pathlib import Path
+from typing import Union
 
+import git
 from easy_infra import __project_name__, __version__, utils
 
 CONFIG_FILE = Path(f"{__project_name__}.yml").absolute()

--- a/tasks.py
+++ b/tasks.py
@@ -438,13 +438,13 @@ def tag(_c, push=False, debug=False):
     if debug:
         getLogger().setLevel("DEBUG")
 
-    if REPO.is_dirty(untracked_files=True):
+    if constants.REPO.is_dirty(untracked_files=True):
         LOG.error("Tagging a release requires a clean git directory to avoid confusion")
         sys.exit(1)
 
     version_tag = f"v{__version__}"
-    head_commit_message = REPO.head.commit.message
-    remote = REPO.remote()
+    head_commit_message = constants.REPO.head.commit.message
+    remote = constants.REPO.remote()
 
     if not head_commit_message.startswith("Bump version: "):
         LOG.warning(
@@ -452,14 +452,14 @@ def tag(_c, push=False, debug=False):
         )
         remote.pull("main")
         LOG.debug("Completed a git pull")
-        head_commit_message = REPO.head.commit.message
+        head_commit_message = constants.REPO.head.commit.message
 
         if not head_commit_message.startswith("Bump version: "):
             LOG.error("HEAD still does not appear to be a release")
             sys.exit(1)
 
     LOG.info(f"Tagging the local repo with {version_tag}...")
-    REPO.create_tag(version_tag, message=head_commit_message)
+    constants.REPO.create_tag(version_tag, message=head_commit_message)
 
     if push:
         LOG.info(f"Pushing the {version_tag} tag to GitHub...")

--- a/tasks.py
+++ b/tasks.py
@@ -11,10 +11,8 @@ import sys
 from datetime import datetime
 from logging import basicConfig, getLogger
 from pathlib import Path
-from typing import Union
 
 import docker
-import git
 from bumpversion.cli import main as bumpversion
 from easy_infra import __project_name__, __version__, constants, utils
 from invoke import task


### PR DESCRIPTION
# Contributor Comments

This refactors the logic for retrieving image tags (`CONTEXT`).  This allows us to load and use it in `ci.yml` without duplicating logic, in preparation for future additional refactors.

This should also make the docker image signature validation process more precise by pointing to the versioned tag instead of the appropriate "latest" tag, even though the docker image digests are the same.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, align your PR
  title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)