### PR TITLE
Allow bringing your own TERRAFORM_VERSION via env var

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,8 +24,13 @@ if [ "$#" -eq 0 ]; then
   if [ -x "$(which packer)" ]; then
     echo -e "packer\t\t ${PACKER_VERSION}"
   fi
+  current_version=$(cat /home/easy_infra/.tfenv/version)
   if [ -x "$(which terraform)" ]; then
-    echo -e "terraform\t ${TERRAFORM_VERSION}"
+    if [[ "${TERRAFORM_VERSION}" != "${current_version}" ]]; then
+      echo -e "terraform\t ${TERRAFORM_VERSION} (customized)"
+    else
+      echo -e "terraform\t ${TERRAFORM_VERSION}"
+    fi
   fi
 
   exec bash

--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -88,6 +88,16 @@ Customizing tfsec
     docker run --env-file <(env | grep ^TFSEC_) -v $(pwd):/iac easy_infra:latest terraform validate
 
 
+Preinstalled Hooks
+^^^^^^^^^^^^^^^^^^
+
+There are some preinstalled hooks in ``/opt/hooks/bin/`` which apply to terraform commands::
+
+* If the ``TERRAFORM_VERSION`` environment variable is customized, easy_infra will attempt to install and switch to that version at runtime.
+* If ``AUTODETECT`` is set to ``true``, easy_infra will attempt to detect and install the correct version of terraform for each folder that a
+  ``terraform`` command runs in.
+
+
 Terraform Caching
 ^^^^^^^^^^^^^^^^^
 

--- a/hooks/40-set_default_terraform_version.sh
+++ b/hooks/40-set_default_terraform_version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# register_hook: terraform
+
+# All private functions (start with _) come from here
+# shellcheck disable=SC1091
+source /usr/local/bin/common.sh
+
+fully_qualified_script=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
+
+current_version=$(cat /home/easy_infra/.tfenv/version)
+
+if [[ "${TERRAFORM_VERSION}" == "${current_version}" ]]; then
+  exit 0
+fi
+
+# TERRAFORM_VERSION is not the installed and active version; make it so
+tfenv install "${TERRAFORM_VERSION}" &>/dev/null
+return=$?
+if [[ "${return}" != 0 ]]; then
+  message="Unable to install Terraform ${TERRAFORM_VERSION}, continuing to use version ${current_version}..."
+  _feedback WARNING "${message}"
+  # shellcheck disable=SC2154 # dir is exported in the parent process, see functions.j2
+  _log "easy_infra.hook" info failure "${fully_qualified_script}" "${dir}" string "${message}"
+  exit 0
+fi
+
+_feedback INFORMATIONAL "Switching Terraform version to ${TERRAFORM_VERSION}..."
+tfenv use "${TERRAFORM_VERSION}" &>/dev/null
+exit $?

--- a/hooks/40-set_default_terraform_version.sh
+++ b/hooks/40-set_default_terraform_version.sh
@@ -5,7 +5,6 @@
 # shellcheck disable=SC1091
 source /usr/local/bin/common.sh
 
-fully_qualified_script=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
 
 current_version=$(cat /home/easy_infra/.tfenv/version)
 
@@ -19,6 +18,7 @@ return=$?
 if [[ "${return}" != 0 ]]; then
   message="Unable to install Terraform ${TERRAFORM_VERSION}, continuing to use version ${current_version}..."
   _feedback WARNING "${message}"
+  fully_qualified_script=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
   # shellcheck disable=SC2154 # dir is exported in the parent process, see functions.j2
   _log "easy_infra.hook" info failure "${fully_qualified_script}" "${dir}" string "${message}"
   exit 0

--- a/hooks/40-set_default_terraform_version.sh
+++ b/hooks/40-set_default_terraform_version.sh
@@ -24,6 +24,6 @@ if [[ "${return}" != 0 ]]; then
   exit 0
 fi
 
-_feedback INFORMATIONAL "Switching Terraform version to ${TERRAFORM_VERSION}..."
+_feedback INFORMATIONAL "Switching Terraform version to ${TERRAFORM_VERSION} due to the provided TERRAFORM_VERSION environment variable..."
 tfenv use "${TERRAFORM_VERSION}" &>/dev/null
 exit $?

--- a/tests/test.py
+++ b/tests/test.py
@@ -258,8 +258,10 @@ def run_terraform(*, image: str, final: bool = False):
         "bind": fluent_bit_config_container,
         "mode": "ro",
     }
-    hooks_no_network_success_dir = TESTS_PATH.joinpath("terraform/hooks/secure_1_1")
-    hooks_no_network_success_volumes = {hooks_no_network_success_dir: {"bind": working_dir, "mode": "rw"}}
+    hooks_secure_terraform_v_1_1_dir = TESTS_PATH.joinpath("terraform/hooks/secure_1_1")
+    hooks_secure_terraform_v_1_1_dir_volumes = {
+        hooks_secure_terraform_v_1_1_dir: {"bind": working_dir, "mode": "rw"}
+    }
 
     # Base tests
     command = "./test.sh"
@@ -507,7 +509,7 @@ def run_terraform(*, image: str, final: bool = False):
             1,
         ),  # This tests the terraform version switching hook failback due to no network (see exec_tests below)
         # It fails because terraform/hooks/secure_0_14/secure.tf cannot be validated with the version of terraform
-        # that TERRAFORM_VERSION indicates
+        # that TERRAFORM_VERSION indicates by default
     ]
     LOG.debug(
         "Testing the easy_infra hooks with no network access, against various terraform configurations, expecting failures"
@@ -527,13 +529,28 @@ def run_terraform(*, image: str, final: bool = False):
             0,
         ),  # This tests the terraform version switching hook failback due to no network (see exec_tests below)
         # It succeeds because only terraform/hooks/secure_1_1/secure.tf is tested, which will validate properly with the version of terraform that
-        # TERRAFORM_VERSION indicates
+        # TERRAFORM_VERSION indicates by default
+        (
+            {
+                "DISABLE_HOOKS": "false",
+                "AUTODETECT": "false",
+                "DISABLE_SECURITY": "true",
+                "TERRAFORM_VERSION": "1.1.8",
+            },
+            '/bin/bash -c "terraform init -backend=false && terraform validate"',
+            1,
+        ),  # This tests the bring-your-own TERRAFORM_VERSION hook, regardless of the built-in security tools
+        # It fails because only terraform/hooks/secure_1_1/secure.tf is tested, but it requires a version of terraform newer then the provided
+        # TERRAFORM_VERSION environment variable specifies
     ]
     LOG.debug(
         "Testing the easy_infra hooks with no network access, against various terraform configurations, expecting successes"
     )
     num_tests_ran += exec_tests(
-        tests=tests, volumes=hooks_no_network_success_volumes, image=image, network_mode="none"
+        tests=tests,
+        volumes=hooks_secure_terraform_v_1_1_dir_volumes,
+        image=image,
+        network_mode="none",
     )
 
     # Ensure insecure configurations still succeed when security checks are

--- a/tests/test.py
+++ b/tests/test.py
@@ -491,6 +491,18 @@ def run_terraform(*, image: str, final: bool = False):
             '/bin/bash -c "terraform init -backend=false && terraform validate"',
             1,
         ),  # This tests DISABLE_HOOKS; it fails because the terraform version used is incorrect
+        (
+            {
+                "DISABLE_HOOKS": "false",
+                "AUTODETECT": "false",
+                "DISABLE_SECURITY": "true",
+                "TERRAFORM_VERSION": "1.1.8",
+            },
+            '/bin/bash -c "terraform init -backend=false && terraform validate"',
+            1,
+        ),  # This tests the bring-your-own TERRAFORM_VERSION hook, regardless of the built-in security tools
+        # It succeeds because only terraform/hooks/secure_1_1/secure.tf is tested, and it fails because it requires a version of terraform newer then
+        # the provided TERRAFORM_VERSION environment variable specifies
     ]
     LOG.debug("Testing the easy_infra hooks against various terraform configurations")
     num_tests_ran += exec_tests(tests=tests, volumes=hooks_config_volumes, image=image)
@@ -538,10 +550,10 @@ def run_terraform(*, image: str, final: bool = False):
                 "TERRAFORM_VERSION": "1.1.8",
             },
             '/bin/bash -c "terraform init -backend=false && terraform validate"',
-            1,
+            0,
         ),  # This tests the bring-your-own TERRAFORM_VERSION hook, regardless of the built-in security tools
-        # It fails because only terraform/hooks/secure_1_1/secure.tf is tested, but it requires a version of terraform newer then the provided
-        # TERRAFORM_VERSION environment variable specifies
+        # It succeeds because only terraform/hooks/secure_1_1/secure.tf is tested, and it requires a version of terraform newer then the provided
+        # TERRAFORM_VERSION environment variable specifies, but because there is no network access the change does not take place
     ]
     LOG.debug(
         "Testing the easy_infra hooks with no network access, against various terraform configurations, expecting successes"


### PR DESCRIPTION
# Contributor Comments

If you specify a `TERRAFORM_VERSION` valid version, it should now use it as the default, assuming hooks are enabled.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.