### PR TITLE
test: fix test failure

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -22,6 +22,7 @@ LOG = getLogger(__project_name__)
 CLIENT = docker.from_env()
 
 basicConfig(level=constants.LOG_DEFAULT, format=constants.LOG_FORMAT)
+getLogger("urllib3").setLevel(constants.LOG_DEFAULT)
 
 
 def process_container(*, container: docker.models.containers.Container) -> None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -402,9 +402,9 @@ def run_terraform(*, image: str, final: bool = False):
         )
 
         if autodetect_status == "true":
-            # Use the index of the 'invalid' dir as the expected number of logs, since it fails at invalid. Note that the general_test_dirs list
-            # should be sorted
-            invalid_dir_index = general_test_dirs.index(invalid_test_dir)
+            # Use the index of the 'invalid' dir as the expected number of logs, since it fails at invalid, + 1 to adjust for 0-indexing. Note that
+            # the general_test_dirs list needs to be alphabetically sorted
+            invalid_dir_index = general_test_dirs.index(invalid_test_dir) + 1
             # One log for each folder that would be encountered
             logs_from_disable_hooks = invalid_dir_index
             expected_number_of_logs = invalid_dir_index + logs_from_disable_hooks

--- a/tests/test.py
+++ b/tests/test.py
@@ -313,7 +313,10 @@ def run_terraform(*, image: str, final: bool = False):
     # There is always one log for each security tool, regardless of if that tool is installed in the image being used.  If a tool is not in the PATH
     # and executable, a log message indicating that is generated.
     number_of_security_tools = len(CONFIG["commands"]["terraform"]["security"])
+    # This list needs to be sorted because it uses pathlib's rglob, which (currently) uses os.scandir, which is documented to yield entries in
+    # arbitrary order https://docs.python.org/3/library/os.html#os.scandir
     general_test_dirs = [dir for dir in general_test_dir.rglob("*") if dir.is_dir()]
+    general_test_dirs.sort()
     general_test_dirs_containing_only_files = []
     for directory in general_test_dirs:
         items_in_dir = directory.iterdir()
@@ -399,7 +402,8 @@ def run_terraform(*, image: str, final: bool = False):
         )
 
         if autodetect_status == "true":
-            # Use the index of the 'invalid' dir as the expected number of logs, since it fails at invalid
+            # Use the index of the 'invalid' dir as the expected number of logs, since it fails at invalid. Note that the general_test_dirs list
+            # should be sorted
             invalid_dir_index = general_test_dirs.index(invalid_test_dir)
             # One log for each folder that would be encountered
             logs_from_disable_hooks = invalid_dir_index


### PR DESCRIPTION
# Contributor Comments

This fixes a bug in the tests, not a bug in the actual code.  pathlib's Path globbing uses os.scandir which yields entries in an arbitrary order, so we need to sort them first and add 1 to account for 0-indexing.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.