### PR TITLE
Ensure cosign only retrieves digests from the local daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
         run: |
           version_tag=$(pipenv run python -c "from easy_infra import constants; \
                                               print(constants.CONTEXT['${STAGE}']['buildargs']['VERSION'])")
-          # Use docker inspect because it only works on local images
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
                    "seiso/easy_infra:${version_tag}" )
           echo -n "${COSIGN_PASSWORD}" |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,9 @@ jobs:
         run: |
           version_tag=$(pipenv run python -c "from easy_infra import constants; \
                                               print(constants.CONTEXT['${STAGE}']['buildargs']['VERSION'])")
-          DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:${version_tag}" |
-                   jq -r '.Descriptor.digest')
+          # Use docker inspect because it only works on local images
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+                   "seiso/easy_infra:${version_tag}" )
           echo -n "${COSIGN_PASSWORD}" |
           cosign sign --key cosign.key   \
             -a git_sha="${GITHUB_SHA}"   \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,9 @@ jobs:
                      "${TAG#v}-aws"
                      "${TAG#v}-az"
                      "${TAG#v}"; do
-            DIGEST=$(docker manifest inspect --verbose "seiso/easy_infra:$tag" |
-                     jq -r '.Descriptor.digest') ;
+            # Use docker inspect because it only works on local images
+            DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+                     "seiso/easy_infra:${tag}" )
             echo -n "${COSIGN_PASSWORD}" |
             cosign sign --key cosign.key
               -a git_sha="${GITHUB_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
                      "${TAG#v}-aws"
                      "${TAG#v}-az"
                      "${TAG#v}"; do
-            # Use docker inspect because it only works on local images
             DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
                      "seiso/easy_infra:${tag}" )
             echo -n "${COSIGN_PASSWORD}" |


### PR DESCRIPTION
# Contributor Comments

Previously, the method of retrieving the digest associated to an image tag (`docker manifest inspect`) called the local daemon, which would look up the digest locally, but if it didn't exist locally it would pull from the default upstream registry.  This new approach (`docker inspect`) will only pull information locally, removing the possibility of accidentally signing an image that an attacker pushed to a registry with a matching tag.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.