### PR TITLE
fix: cosign image reference in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
         run: |
           version_tag=$(pipenv run python -c "from easy_infra import constants; \
                                               print(constants.CONTEXT['${STAGE}']['buildargs']['VERSION'])")
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
-                   "seiso/easy_infra:${version_tag}" )
+          IMAGE_AND_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+                  "seiso/easy_infra:${version_tag}" )
           echo -n "${COSIGN_PASSWORD}" |
           cosign sign --key cosign.key   \
             -a git_sha="${GITHUB_SHA}"   \
             -a tag="${version_tag}"      \
-            "seiso/easy_infra@${DIGEST}"
+            "${IMAGE_AND_DIGEST}"
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           STAGE: ${{ matrix.stage }}


### PR DESCRIPTION
# Contributor Comments

This fixes the cosign signing process.  Previously we were specifying "seiso/easy_infra@seiso/easy_infra@sha256:d729..." as the image (duplicate `seiso/easy_infra`)

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.