### PR TITLE
Checkout main when cutting the release

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: main
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python_version }}


### PR DESCRIPTION
# Contributor Comments

Previously, `actions/checkout` was following the default checkout process which is to checkout the SHA of the commit which triggered the event.  This means that it didn't account for the new commit which was pushed during the prior step of the pipeline.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
