### PR TITLE
test: fix log output tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -91,7 +91,7 @@ def is_expected_file_length(
     is expected, else False
     """
     exit_code, output = container.exec_run(
-        cmd=f"/bin/bash -c \"wc -l {log_path} | awk '{{print $1}}'\""
+        cmd=f"/bin/bash -c \"set -o pipefail; wc -l {log_path} | awk '{{print $1}}'\""
     )
     sanitized_output = int(output.decode("utf-8").strip())
     if exit_code != 0:


### PR DESCRIPTION
# Contributor Comments

Currently the tests should be failing because of a misconfiguration (not an issue in the `easy_infra` runtime), but they are not because pipefail is not turned on.  The `wc -l` on its own is failing, but the exit code is getting eaten by the `| awk`.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [ ] Rebase your branch against the latest commit of the target branch
- [ ] If you are adding a dependency, please explain how it was chosen
- [ ] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [ ] If there is an issue associated with your Pull Request, link the issue to the PR.