### PR TITLE
ci: Fix image signing

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Sign the image
         run: |
           version_tag=$(pipenv run python -c "from easy_infra import constants; \
-                                              print(constants.CONTEXT['${STAGE}']['buildargs']['VERSION'])")
+                                              print(constants.CONTEXT['${STAGE}']['buildargs']['EASY_INFRA_VERSION'])")
           IMAGE_AND_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
                   "seiso/easy_infra:${version_tag}" )
           echo -n "${COSIGN_PASSWORD}" |


### PR DESCRIPTION
# Contributor Comments

In ec881f02567ecab6d9c701e78610c2fac2655e18 we renamed `VERSION` to `EASY_INFRA_VERSION` but forgot to adjust the reference to `VERSION` during image signing with cosign.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
