### PR TITLE
Update KICS

### DIFF
--- a/build/Dockerfile.j2
+++ b/build/Dockerfile.j2
@@ -25,6 +25,8 @@
 
 FROM base as final
 
+USER easy_infra
+
 {% for dockerfrag in dockerfrag_tools %}
 {{ dockerfrag }}
 {% endfor %}

--- a/build/Dockerfile.j2
+++ b/build/Dockerfile.j2
@@ -1,3 +1,9 @@
+{# These ARGs are needed because they go out of scope at the end of the build stage where it was defined #}
+{# https://docs.docker.com/engine/reference/builder/#scope #}
+{% for argument in arguments %}
+ARG {{ argument }}
+{% endfor %}
+
 {# The dockerfile base must start with FROM ... AS base #}
 {{ dockerfile_base }}
 

--- a/build/Dockerfile.kics
+++ b/build/Dockerfile.kics
@@ -10,6 +10,4 @@ ENV KICS_LIBRARY_PATH="/home/easy_infra/.kics/assets/libraries"
 ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/checkmarx/kics.git "${HOME}/.kics" --depth 1 --branch ${KICS_VERSION} \
- && rm -rf "${HOME}/.kics/.git" \
- && mkdir -p "${KICS_JSON_REPORT_PATH}"
+RUN mkdir -p "${KICS_JSON_REPORT_PATH}"

--- a/build/Dockerfile.kics
+++ b/build/Dockerfile.kics
@@ -1,8 +1,7 @@
-ARG EASY_INFRA_TAG
+ARG KICS_VERSION
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS kics
+FROM checkmarx/kics:"${KICS_VERSION}-debian" AS kics
 
-ARG KICS_ARCH
 ARG KICS_VERSION
 ENV KICS_VERSION="${KICS_VERSION}"
 ENV SKIP_KICS="false"
@@ -11,13 +10,6 @@ ENV KICS_LIBRARY_PATH="/home/easy_infra/.kics/assets/libraries"
 ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-USER root
-RUN curl -L "https://github.com/checkmarx/kics/releases/download/${KICS_VERSION}/kics_${KICS_VERSION#v}_linux_${KICS_ARCH}.tar.gz" -o /usr/local/bin/kics.tar.gz \
- && tar -xvf /usr/local/bin/kics.tar.gz -C /usr/local/bin/ kics \
- && rm -f /usr/local/bin/kics.tar.gz \
- && chmod 0755 /usr/local/bin/kics \
- && chown root: /usr/local/bin/kics \
- && su easy_infra -c "git clone https://github.com/checkmarx/kics.git /home/easy_infra/.kics --depth 1 --branch ${KICS_VERSION}" \
- && rm -rf /home/easy_infra/.kics/.git \
+RUN git clone https://github.com/checkmarx/kics.git "${HOME}/.kics" --depth 1 --branch ${KICS_VERSION} \
+ && rm -rf "${HOME}/.kics/.git" \
  && mkdir -p "${KICS_JSON_REPORT_PATH}"
-USER easy_infra

--- a/build/Dockerfrag.kics
+++ b/build/Dockerfrag.kics
@@ -6,10 +6,9 @@ ENV KICS_LIBRARY_PATH="/home/easy_infra/.kics/assets/libraries"
 ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/kics /usr/local/bin/kics
-COPY --from=kics --chown=easy_infra:easy_infra /root/.kics /home/easy_infra/.kics
-COPY --from=kics --chown=easy_infra:easy_infra /tmp/reports/kics /tmp/reports/kics
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/assets/libraries /home/easy_infra/.kics/assets/libraries
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/assets/queries /home/easy_infra/.kics/assets/queries
+COPY --from=kics --chown=easy_infra:easy_infra /tmp/reports/kics /tmp/reports/kics
 
 # Intentionally left out because KICS is not currently used in the Terraform image
 #COPY --from=kics --chown=easy_infra:easy_infra /root/.terraform.d/plugins/linux_amd64 /home/easy_infra/.terraform.d/plugins/linux_amd64

--- a/build/Dockerfrag.kics
+++ b/build/Dockerfrag.kics
@@ -8,6 +8,8 @@ ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/kics /usr/local/bin/kics
 COPY --from=kics --chown=easy_infra:easy_infra /root/.kics /home/easy_infra/.kics
 COPY --from=kics --chown=easy_infra:easy_infra /tmp/reports/kics /tmp/reports/kics
+COPY --from=kics --chown=easy_infra:easy_infra /app/bin/assets/libraries /home/easy_infra/.kics/assets/libraries
+COPY --from=kics --chown=easy_infra:easy_infra /app/bin/assets/queries /home/easy_infra/.kics/assets/queries
 
 # Intentionally left out because KICS is not currently used in the Terraform image
 #COPY --from=kics --chown=easy_infra:easy_infra /root/.terraform.d/plugins/linux_amd64 /home/easy_infra/.terraform.d/plugins/linux_amd64

--- a/build/Dockerfrag.kics
+++ b/build/Dockerfrag.kics
@@ -5,6 +5,6 @@ ENV KICS_INCLUDE_QUERIES_PATH="/home/easy_infra/.kics/assets/queries"
 ENV KICS_LIBRARY_PATH="/home/easy_infra/.kics/assets/libraries"
 ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 
-COPY --from=kics --chown=easy_infra:easy_infra /usr/local/bin/kics /usr/local/bin/kics
-COPY --from=kics --chown=easy_infra:easy_infra /home/easy_infra/.kics /home/easy_infra/.kics
+COPY --from=kics --chown=easy_infra:easy_infra /app/bin/kics /usr/local/bin/kics
+COPY --from=kics --chown=easy_infra:easy_infra /root/.kics /home/easy_infra/.kics
 COPY --from=kics --chown=easy_infra:easy_infra /tmp/reports/kics /tmp/reports/kics

--- a/build/Dockerfrag.kics
+++ b/build/Dockerfrag.kics
@@ -8,3 +8,7 @@ ENV KICS_JSON_REPORT_PATH="/tmp/reports/kics"
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/kics /usr/local/bin/kics
 COPY --from=kics --chown=easy_infra:easy_infra /root/.kics /home/easy_infra/.kics
 COPY --from=kics --chown=easy_infra:easy_infra /tmp/reports/kics /tmp/reports/kics
+
+# Intentionally left out because KICS is not currently used in the Terraform image
+#COPY --from=kics --chown=easy_infra:easy_infra /root/.terraform.d/plugins/linux_amd64 /home/easy_infra/.terraform.d/plugins/linux_amd64
+#COPY --from=kics --chown=easy_infra:easy_infra /usr/bin/terraformer /usr/local/bin/terraformer

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -57,7 +57,6 @@ packages:
     version: v2.0.5
     version_argument: --version
   kics:
-    allow_update: false
     version: v1.5.1
     version_argument: version
   terraform:

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -15,6 +15,13 @@ _anchors:
     description: initialization
   - command: terraform validate
     description: validation
+environments:
+  aws:
+    packages:
+    - aws-cli
+  azure:
+    packages:
+    - azure-cli
 packages:
   ansible:
     aliases:
@@ -45,19 +52,22 @@ packages:
     version: 2.2.125
     version_argument: --version
   consul-template:
-    helper: ["all"]
+    helper:
+    - all
     version: v0.29.5
     version_argument: --version
   envconsul:
-    helper: ["all"]
+    helper:
+    - all
     version: v0.13.1
     version_argument: --version
   fluent-bit:
-    helper: ["all"]
+    helper:
+    - all
     version: v2.0.5
     version_argument: --version
   kics:
-    version: v1.5.1
+    version: v1.6.6
     version_argument: version
   terraform:
     file_extensions: *id001
@@ -66,20 +76,17 @@ packages:
     version: 1.3.4
     version_argument: version
   terratag:
-    helper: ["terraform"]
+    helper:
+    - terraform
     version: v0.1.48
   tfenv:
     allow_filter:
     - match: exec
       position: 0
     file_extensions: *id001
-    helper: ["terraform"]
+    helper:
+    - terraform
     security: *id002
     validation: *id003
     version: v3.0.0
     version_argument: --version
-environments:
-  aws:
-    packages: [aws-cli]
-  azure:
-    packages: [azure-cli]

--- a/tasks.py
+++ b/tasks.py
@@ -268,6 +268,7 @@ def build_and_tag(
     config["dockerfile_base"] = constants.BUILD.joinpath("Dockerfile.base").read_text(
         encoding="UTF-8"
     )
+    config["arguments"] = []
 
     LOG.debug(
         f"Rendering {constants.DOCKERFILE_INPUT_FILE} to build seiso/easy_infra_base for {tool=} and {environment=}"
@@ -328,6 +329,9 @@ def build_and_tag(
                     encoding="UTF-8"
                 )
             )
+            argument = f"{security_tool.upper()}_VERSION"
+            LOG.debug(f"Adding a header argument of {argument}...")
+            config["arguments"].append(argument)
     except FileNotFoundError:
         LOG.exception(f"A file required to build a {tool} container was not found")
         sys.exit(1)

--- a/tasks.py
+++ b/tasks.py
@@ -112,11 +112,9 @@ def setup_buildargs(*, tool: str, environment: str | None = None, trace: bool) -
     # Add the platform-based build args (imperfect)
     if platform.machine().lower() == "arm64":
         buildargs["BUILDARCH"] = "arm64"
-        buildargs["KICS_ARCH"] = "arm64"
         buildargs["AWS_CLI_ARCH"] = "aarch64"
     else:
         buildargs["BUILDARCH"] = "amd64"
-        buildargs["KICS_ARCH"] = "x64"
         buildargs["AWS_CLI_ARCH"] = "x86_64"
 
     # Add the tool version buildarg

--- a/tests/test.py
+++ b/tests/test.py
@@ -988,7 +988,7 @@ def run_ansible(*, image: str) -> None:
         # This tests the "customizations" idea from easy_infra.yml and functions.j2
         (
             {
-                "KICS_EXCLUDE_SEVERITIES": "high,medium",
+                "KICS_EXCLUDE_SEVERITIES": "high,medium,low",
             },
             "ansible-playbook insecure.yml --check",
             4,


### PR DESCRIPTION
# Contributor Comments

This moves to using the upstream KICS docker images from docker hub at build time.  This is a workaround due to KICS no longer releasing binaries.  See https://github.com/Checkmarx/kics/discussions/4744 and https://github.com/Checkmarx/kics/releases/tag/v1.5.1 

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.
