### PR TITLE
Automate test maintenance when updating components

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,11 +26,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:1c00a14f5a3ed0339d38d2e2e5b74ea2591df5861c0936bb292b84ccf3a78d83",
-                "sha256:72702205200b2a638358369d90c222d74ebc376787af8fb2f7f2a86f7b5cc85f"
+                "sha256:10e0ad5f7b79c435179d0d0f0df69998c4eef4597534aae44910db060baeb907",
+                "sha256:1493fe8bd3dfd73dc35bd53c9d5b6e49ead98497c47b2307662556a5692d29d7"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.12.12"
+            "version": "==2.12.13"
         },
         "babel": {
             "hashes": [
@@ -58,11 +58,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
+            "version": "==2022.12.7"
         },
         "charset-normalizer": {
             "hashes": [
@@ -77,7 +77,7 @@
                 "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
                 "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==0.3.6"
         },
         "docker": {
@@ -98,19 +98,19 @@
         },
         "gitdb": {
             "hashes": [
-                "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd",
-                "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"
+                "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a",
+                "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.0.9"
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.10"
         },
         "gitpython": {
             "hashes": [
-                "sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f",
-                "sha256:cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd"
+                "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8",
+                "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"
             ],
             "index": "pypi",
-            "version": "==3.1.29"
+            "version": "==3.1.30"
         },
         "idna": {
             "hashes": [
@@ -138,11 +138,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
+                "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
+                "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
-            "version": "==5.10.1"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==5.11.4"
         },
         "jinja2": {
             "hashes": [
@@ -248,19 +248,19 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3",
+                "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==22.0"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
-                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
+                "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
+                "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.4"
+            "version": "==2.6.2"
         },
         "pygments": {
             "hashes": [
@@ -272,26 +272,18 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:3b120505e5af1d06a5ad76b55d8660d44bf0f2fc3c59c2bdd94e39188ee3a4df",
-                "sha256:c2108037eb074334d9e874dc3c783752cc03d0796c88c9a9af282d0f161a1004"
+                "sha256:18783cca3cfee5b83c6c5d10b3cdb66c6594520ffae61890858fe8d932e1c6b4",
+                "sha256:349c8cd36aede4d50a0754a8c0218b43323d13d5d88f4b2952ddfe3e169681eb"
             ],
             "index": "pypi",
-            "version": "==2.15.5"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
+            "version": "==2.15.9"
         },
         "pytz": {
             "hashes": [
-                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
-                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
+                "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a",
+                "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"
             ],
-            "version": "==2022.6"
+            "version": "==2022.7"
         },
         "pyyaml": {
             "hashes": [
@@ -364,11 +356,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d",
-                "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"
+                "sha256:58c140ecd9aa0abbc8ff6da48a266648eac9e5bfc8e49576efd2979bf46f5961",
+                "sha256:c2aeebfcb0e7474f5a820eac6177c7492b1d3c9c535aa21d5ae77cab2f3600e4"
             ],
             "index": "pypi",
-            "version": "==5.3.0"
+            "version": "==6.0.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -436,11 +428,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
-                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
+                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.12"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.13"
         },
         "websocket-client": {
             "hashes": [

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -41,20 +41,20 @@ packages:
   aws-cli:
     aliases:
     - aws
-    version: 2.8.13
+    version: 2.9.11
     version_argument: --version
   azure-cli:
     aliases:
     - az
-    version: 2.42.0-1~focal
+    version: 2.43.0-1~focal
     version_argument: version
   checkov:
-    version: 2.2.125
+    version: 2.2.219
     version_argument: --version
   consul-template:
     helper:
     - all
-    version: v0.29.5
+    version: v0.29.6
     version_argument: --version
   envconsul:
     helper:
@@ -64,7 +64,7 @@ packages:
   fluent-bit:
     helper:
     - all
-    version: v2.0.5
+    version: v2.0.8
     version_argument: --version
   kics:
     version: v1.6.6
@@ -73,7 +73,7 @@ packages:
     file_extensions: *id001
     security: *id002
     validation: *id003
-    version: 1.3.4
+    version: 1.3.6
     version_argument: version
   terratag:
     helper:

--- a/easy_infra/config.py
+++ b/easy_infra/config.py
@@ -45,29 +45,29 @@ def write_config(*, config: dict, config_file: Path):
         dump(config, file)
 
 
-def update_config_file(*, thing: str, version: str):
+def update_config_file(*, package: str, version: str):
     """Update the easy_infra config file"""
     # Normalize
-    thing = thing.split("/")[-1].lower()
+    package = package.split("/")[-1].lower()
     if isinstance(version, bytes):
         version = version.decode("utf-8").rstrip()
 
     config_file = Path(f"{__project_name__}.yml").absolute()
 
     config = parse_config(config_file=config_file)
-    allow_update = config["packages"][thing].get("allow_update", True)
-    current_version = config["packages"][thing]["version"]
+    allow_update = config["packages"][package].get("allow_update", True)
+    current_version = config["packages"][package]["version"]
 
     if version == current_version:
-        LOG.debug(f"No new versions have been detected for {thing}")
+        LOG.debug(f"No new versions have been detected for {package}")
         return
 
     if not allow_update:
         LOG.warning(
-            f"Not updating {thing} to version {version} because allow_update is set to false"
+            f"Not updating {package} to version {version} because allow_update is set to false"
         )
         return
 
-    config["packages"][thing]["version"] = version
-    LOG.info(f"Updating {thing} to version {version}")
+    config["packages"][package]["version"] = version
+    LOG.info(f"Updating {package} to version {version}")
     write_config(config=config, config_file=config_file)

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -1,7 +1,8 @@
+import re
 import sys
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Pattern, Union
 
 import docker
 import requests
@@ -202,3 +203,33 @@ def get_tags(
         tags = tags[::2]
 
     return tags
+
+
+def update_terraform_required_version(*, test_file: Path, version: str) -> None:
+    """Update the terraform required_version in the tests"""
+    pattern: Pattern[str] = re.compile(r'^([ \t]+)required_version = "[\d.]+"$\n')
+    final_content: list[str] = []
+
+    # Validate
+    if not test_file.is_file():
+        LOG.error(f"{test_file} is not a valid file")
+        sys.exit(1)
+
+    # Read lines of the provided file into a list
+    with test_file.open(encoding="utf-8") as file:
+        file_contents: list[str] = file.readlines()
+
+    # Transform the list to update the required_version line
+    for line in file_contents:
+        if match := pattern.fullmatch(line):
+            # The first grouping is the whitespace
+            whitespace = match.group(1)
+            new_line: str = f'{whitespace}required_version = "{version}"\n'
+            final_content.append(new_line)
+            continue
+
+        final_content.append(line)
+
+    # Load
+    with test_file.open("w", encoding="utf-8") as file:
+        file.writelines(final_content)

--- a/tasks.py
+++ b/tasks.py
@@ -23,7 +23,6 @@ from invoke import task
 from easy_infra import __project_name__, __version__, config, constants, utils
 from tests import test as run_test
 
-# TODO: Does this work on intel?
 platform_machine = platform.machine()
 if platform_machine == "arm64":
     PLATFORM: Union[str, None] = "linux/arm64"
@@ -457,23 +456,30 @@ def update(_c, debug=False):
 
     for package in constants.APT_PACKAGES:
         version = utils.get_latest_release_from_apt(package=package)
-        config.update_config_file(thing=package, version=version)
+        config.update_config_file(package=package, version=version)
 
     for repo in constants.GITHUB_REPOS_RELEASES:
         version = utils.get_latest_release_from_github(repo=repo)
-        config.update_config_file(thing=repo, version=version)
+        config.update_config_file(package=repo, version=version)
 
     for repo in constants.GITHUB_REPOS_TAGS:
         version = utils.get_latest_tag_from_github(repo=repo)
-        config.update_config_file(thing=repo, version=version)
+        config.update_config_file(package=repo, version=version)
 
     for project in constants.HASHICORP_PROJECTS:
         version = utils.get_latest_release_from_hashicorp(project=project)
-        config.update_config_file(thing=project, version=version)
+        config.update_config_file(package=project, version=version)
+        if project == "terraform":
+            test_file: Path = constants.CWD.joinpath(
+                "tests/terraform/hooks/secure_builtin_version/secure.tf"
+            )
+            utils.update_terraform_required_version(
+                test_file=test_file, version=version
+            )
 
     for package in constants.PYTHON_PACKAGES:
         version = utils.get_latest_release_from_pypi(package=package)
-        config.update_config_file(thing=package, version=version)
+        config.update_config_file(package=package, version=version)
 
     # Update the CI dependencies
     image = "python:3.10"

--- a/tests/terraform/hooks/secure_1_3/secure.tf
+++ b/tests/terraform/hooks/secure_1_3/secure.tf
@@ -1,3 +1,0 @@
-terraform {
-  required_version = "1.3.4"
-}

--- a/tests/terraform/hooks/secure_builtin_version/secure.tf
+++ b/tests/terraform/hooks/secure_builtin_version/secure.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "1.3.6"
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -333,9 +333,11 @@ def run_terraform(*, image: str) -> None:
         "bind": fluent_bit_config_container,
         "mode": "ro",
     }
-    hooks_secure_terraform_v_1_3_dir = TESTS_PATH.joinpath("terraform/hooks/secure_1_3")
-    hooks_secure_terraform_v_1_3_dir_volumes = {
-        hooks_secure_terraform_v_1_3_dir: {"bind": working_dir, "mode": "rw"}
+    hooks_secure_terraform_v_builtin_dir = TESTS_PATH.joinpath(
+        "terraform/hooks/secure_builtin_version"
+    )
+    hooks_secure_terraform_v_builtin_dir_volumes = {
+        hooks_secure_terraform_v_builtin_dir: {"bind": working_dir, "mode": "rw"}
     }
     hooks_secure_terraform_v_0_14_dir = TESTS_PATH.joinpath(
         "terraform/hooks/secure_0_14"
@@ -660,7 +662,7 @@ def run_terraform(*, image: str) -> None:
             '/bin/bash -c "terraform init -backend=false && terraform validate"',
             0,
         ),  # This tests the terraform version switching hook failback due to no network (see exec_tests below)
-        # It succeeds because only terraform/hooks/secure_1_3/secure.tf is tested, which will validate properly with the version of terraform that
+        # It succeeds because only terraform/hooks/secure_builtin_version/secure.tf is tested, which will validate properly with the version of terraform that
         # TERRAFORM_VERSION indicates by default
         (
             {
@@ -672,7 +674,7 @@ def run_terraform(*, image: str) -> None:
             '/bin/bash -c "terraform init -backend=false && terraform validate"',
             0,
         ),  # This tests the bring-your-own TERRAFORM_VERSION hook, regardless of the built-in security tools
-        # It succeeds because only terraform/hooks/secure_1_3/secure.tf is tested, and it requires a version of terraform newer then the provided
+        # It succeeds because only terraform/hooks/secure_builtin_version/secure.tf is tested, and it requires a version of terraform newer then the provided
         # TERRAFORM_VERSION environment variable specifies, but because there is no network access the change does not take place
     ]
     LOG.debug(
@@ -680,7 +682,7 @@ def run_terraform(*, image: str) -> None:
     )
     num_tests_ran += exec_tests(
         tests=tests,
-        volumes=hooks_secure_terraform_v_1_3_dir_volumes,
+        volumes=hooks_secure_terraform_v_builtin_dir_volumes,
         image=image,
         network_mode="none",
     )
@@ -708,7 +710,7 @@ def run_terraform(*, image: str) -> None:
             "terraform plan || false",
             1,
         ),  # Not supported; reproduce "Too many command line arguments. Configuration path expected." error
-        #     locally with `docker run -e DISABLE_SECURITY=true -v $(pwd)/tests/terraform/tool/checkov:/iac seiso/easy_infra:latest terraform plan
+        #     locally with `docker run -e DISABLE_SECURITY=true -v $(pwd)/tests/terraform/tool/checkov:/iac seiso/easy_infra:latest-terraform terraform plan
         #     \|\| false`, prefer passing the commands through bash like the following test
         (
             {},


### PR DESCRIPTION
# Contributor Comments

This PR runs `pipenv run invoke update` after adding some helper logic to maintain the tests when updating components.  We have a test file that specifies a terraform `required_version`, but it must be aligned with the default/built-in version of terraform from `easy_infra.yml`.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
