### PR TITLE
fix: find dirnames per file to support large numbers of discovered files

### DIFF
--- a/build/functions.j2
+++ b/build/functions.j2
@@ -129,7 +129,7 @@ function {{ "scan_" ~ function if scan else function }}() {
 {%- for file_extension in file_extensions %}
     files=$(find . -iname "*.{{ file_extension }}" -type f)
     if [[ "${files}" ]]; then
-      dirs+=($(for file in "${files}"; do dirname ${file}; done | sort -u | xargs readlink --canonicalize))
+      dirs+=($(for file in ${files}; do dirname ${file}; done | sort -u | xargs readlink --canonicalize))
     fi
 {%- endfor %}
 {%- else %}


### PR DESCRIPTION
# Contributor Comments

I am working on performing `easy_infra` scans on 11,590 terraform module repos, and it is discovering 125,452 files.  When you attempt to run a scan with that many files it fails with the following error due to `"${files}"` because `dirname` is being passed all 125k files, space delimited, in a single iteration of a for loop.  By removing the `"`s, it performs one `dirname` per file.

```bash
/functions: line 394: /usr/bin/dirname: Argument list too long
readlink: missing operand
Try 'readlink --help' for more information.
```

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
