### PR TITLE
fix: allow storing information in rekor

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -272,9 +272,9 @@ jobs:
           image_and_digest=$(docker inspect --format='{{index .RepoDigests 0}}' \
                   "${image_and_versioned_tag}" )
           echo -n "${COSIGN_PASSWORD}" |
-          cosign sign --key cosign.key   \
-            -a git_sha="${GITHUB_SHA}"   \
-            -a tag="${versioned_tag}"      \
+          cosign sign --yes --key cosign.key \
+            -a git_sha="${GITHUB_SHA}"       \
+            -a tag="${versioned_tag}"        \
             "${image_and_digest}"
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
# Contributor Comments

We're currently getting this failure in [our pipelines](https://github.com/SeisoLLC/easy_infra/actions/runs/4406194710/jobs/7720583902) due to cosign v2 changes.  Since we are OK with signing info being stored in rekor, we added `--yes` to the cosign signature process.

```
By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
[32](https://github.com/SeisoLLC/easy_infra/actions/runs/4406194710/jobs/7720583902#step:10:33)
Are you sure you would like to continue? [y/N] Error: signing [seiso/easy_infra@sha256:0e8c1125d2e157b9f53b859973c086202c1ef1064fbea435156c5bfb26f8f052]: signing digest: should upload to tlog: invalid input "***" (allowed values y, n)
[33](https://github.com/SeisoLLC/easy_infra/actions/runs/4406194710/jobs/7720583902#step:10:34)
main.go:74: error during command execution: signing [seiso/easy_infra@sha256:0e8c1125d2e157b9f53b859973c086202c1ef1064fbea435156c5bfb26f8f052]: signing digest: should upload to tlog: invalid input "***" (allowed values y, n)
[34](https://github.com/SeisoLLC/easy_infra/actions/runs/4406194710/jobs/7720583902#step:10:35)
```

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
