### PR TITLE
feat!: monitor the container filesystem to determine when to rerun scans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 ## Background
 
 To learn more about the design and background of this project, as well as some of the naming standards and concepts, see [the
-documentation](https://easy-infra.readthedocs.io/) under the Technical Details section. You may also want to refer to the other parts of the docs to
-learn about the existing features.
+documentation](https://easy-infra.readthedocs.io/) under the Technical Details section. You may also want to refer to the other parts of the docs to learn about
+the existing features.
 
 ## Getting started
 
 To get started with contributing to this project, you first want to ensure that you can build and test the project locally.
 
-First, ensure you have `docker`, `git`, `pipenv`, and `python3` installed locally, and the `docker` daemon is running. Then run `pipenv install
---deploy --ignore-pipfile --dev` to install the dependencies onto your local system.
+First, ensure you have `docker`, `git`, `pipenv`, and `python3` installed locally, and the `docker` daemon is running. Then run `pipenv install --deploy
+--ignore-pipfile --dev` to install the dependencies onto your local system.
 
 If you'd like to [run the test suite](#running-the-tests), you will also need `grype` downloaded and in your `PATH`.
 
@@ -31,8 +31,7 @@ If you only want to build a specific image, you can pass in a tool and/or an env
 pipenv run invoke build --tool=terraform --environment=none
 ```
 
-To see the list of possible tools, run the following command. If you don't specify a tool, `build` will assume that you want to build "all" of the
-tools.
+To see the list of possible tools, run the following command. If you don't specify a tool, `build` will assume that you want to build "all" of the tools.
 
 ```bash
 pipenv run python3 -c \
@@ -40,8 +39,8 @@ pipenv run python3 -c \
   print(list(constants.TOOLS))"
 ```
 
-To see the possible environments, run the following command. If you don't specify a environment, `build` will assume that you want to build "all" of
-the supported environments for the specified tool(s).
+To see the possible environments, run the following command. If you don't specify a environment, `build` will assume that you want to build "all" of the
+supported environments for the specified tool(s).
 
 ```bash
 pipenv run python -c \
@@ -67,8 +66,7 @@ This will add additional troubleshooting tools to the container, and perform som
 
 ### Running the tests
 
-If you are attempting to run the tests locally, consider running the following to ensure that the user from inside the container can write to the
-host:
+If you are attempting to run the tests locally, consider running the following to ensure that the user from inside the container can write to the host:
 
 ```bash
 find tests -mindepth 1 -type d -exec chmod o+w {} \;
@@ -80,11 +78,11 @@ You can now run the tests locally:
 pipenv run invoke test
 ```
 
-You can pass in the `--tool`, `--environment`, and `--user` arguments to test a specific subset of functionality. See
-the build step to see the `tool` and `environment` possible inputs.
+You can pass in the `--tool`, `--environment`, and `--user` arguments to test a specific subset of functionality. See the build step to see the `tool` and
+`environment` possible inputs.
 
-To see the list of supported users, run the following command. If you don't specify a user, `test` will assume that you
-want to test with all of the supported users.
+To see the list of supported users, run the following command. If you don't specify a user, `test` will assume that you want to test with all of the supported
+users.
 
 ```bash
 pipenv run python3 -c \
@@ -100,7 +98,7 @@ If you'd like to generate an SBOM, run the following:
 pipenv run invoke sbom
 ```
 
-You will now see various `sbom.*.json` files in your current directory, and you can pass in the same `--tool` and `--environment` arguments as
+You will now see various `sbom.*.json` files in your current directory, and you can pass in the same `--tool` and `--environment` arguments as `build`ing.
 
 ### Running vulnerability scans
 
@@ -110,5 +108,5 @@ If you'd like to run the vulnerability scans, run the following:
 pipenv run invoke vulnscan
 ```
 
-You will now see various `vulns.*.json` files in your current directory, and you can pass in the same `--tool` and `--environment` arguments as
-outlined in the build instructions above.
+You will now see various `vulns.*.json` files in your current directory, and you can pass in the same `--tool` and `--environment` arguments as outlined in the
+build instructions above.

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -27,11 +27,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:a1b8543ef9d36ea777194bc9b17f5f8678d2c56ee6a45b2c2f17eec96f242347",
-                "sha256:c81e1c7fbac615037744d067a9bb5f9aeb655edf59b63ee8b59585475d6f80d8"
+                "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324",
+                "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.4"
+            "version": "==2.15.5"
         },
         "babel": {
             "hashes": [
@@ -156,19 +156,19 @@
         },
         "docker": {
             "hashes": [
-                "sha256:5ec18b9c49d48ee145a5b5824bb126dc32fc77931e18444783fc07a7724badc0",
-                "sha256:8308b23d3d0982c74f7aa0a3abd774898c0c4fba006e9c3bde4f68354e470fe2"
+                "sha256:134cd828f84543cbf8e594ff81ca90c38288df3c0a559794c12f2e4b634ea19e",
+                "sha256:dcc088adc2ec4e7cfc594e275d8bd2c9738c56c808de97476939ef67db5af8c2"
             ],
             "index": "pypi",
-            "version": "==6.1.1"
+            "version": "==6.1.2"
         },
         "docutils": {
             "hashes": [
-                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
-                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
+                "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+                "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.19"
+            "version": "==0.20.1"
         },
         "gitdb": {
             "hashes": [
@@ -204,11 +204,11 @@
         },
         "invoke": {
             "hashes": [
-                "sha256:7dcf054c4626b89713da650635c29e9dfeb8a1dd0a14edc60bd3e16f751292ff",
-                "sha256:e86a53046eca453d3e609e7017f65db5f66b947d4d337b60658859eb8c8a80e3"
+                "sha256:a6cc1f06f75bacd0b1e11488fa3bf3e62f85e31f62e2c0172188613ba5b070e2",
+                "sha256:bfc904df1c9e9fe1a881933de661fe054b8db616ff2c4cf78e00407fe473ba5d"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==2.1.2"
         },
         "isort": {
             "hashes": [
@@ -357,11 +357,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4",
-                "sha256:7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"
+                "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f",
+                "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.5.0"
+            "version": "==3.5.1"
         },
         "pygments": {
             "hashes": [
@@ -450,11 +450,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:283c44aa28922bb4223777b44ac0d59af50a279ac7690dfe945bb2b9575dc41b",
-                "sha256:3cfc1c6756ef1b132687b813ec6ea2214cb7a7e5d1dcb2772006cb895a0fa469"
+                "sha256:60c5e04756c1709a98845ed27a2eed7a556af3993afb66e77fec48189f742616",
+                "sha256:61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d"
             ],
             "index": "pypi",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -538,11 +538,11 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40",
-                "sha256:cdf5877568b7e83aa7cf2244ab56a3213de587bbe0ce9d8b9600fc77b455d89e"
+                "sha256:c7d67c13b928645f259d9b847ab5b57fd2d127213ca41ebd880de1f553b7c23b",
+                "sha256:f8c64e28cd700e7ba1f04350d66422b6833b82a796b525a51e740b8cc8dab4b1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.5.1"
+            "version": "==1.5.2"
         },
         "wrapt": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Getting Started
 
-easy_infra is a docker container that simplifies and secures Infrastructure as Code deployments by running security scans prior to running IaC tools.
-It supports three main use cases:
+easy_infra is a docker container that simplifies and secures Infrastructure as Code deployments by running security scans prior to running IaC tools. It
+supports three main use cases:
 
 1. **Experimentation** by supporting interactive use and secure troubleshooting.
 1. **Continuous Integration** as a part of Pull/Merge Request validation.
@@ -15,8 +15,7 @@ In order to run your infrastructure code from within the container, volume mount
 docker run -v $(pwd):/iac seiso/easy_infra:latest-terraform terraform validate
 ```
 
-You can simplify your workflow further by using aliases. For instance, consider putting something like the following in your `.zshrc`, `.bashrc`, or
-similar:
+You can simplify your workflow further by using aliases. For instance, consider putting something like the following in your `.zshrc`, `.bashrc`, or similar:
 
 ```bash
 alias terraform="docker run -v $(pwd):/iac seiso/easy_infra:latest-terraform terraform"
@@ -37,22 +36,20 @@ To learn more, check out [our documentation](https://easy-infra.readthedocs.io/)
 This container provides security features by default.  Deploying an environment using terraform would likely look something like this:
 
 ```bash
-docker run -v $(pwd):/iac seiso/easy_infra:latest-terraform terraform apply -auto-approve
+docker run -v $(pwd):/iac seiso/easy_infra:latest-terraform /bin/bash -c "terraform init && terraform apply -auto-approve"
 ```
 
 What `easy_infra` does in this case is:
 
-1. Perform `terraform` validation, specifically `terraform init && terraform validate`.
-1. Run `terraform` security tools\* serially, and in alphabetical order.
-1. Run the provided `terraform` command, assuming the provided configurations were confirmed as valid and did not fail any of the security policy
-   validation.
-
-\* In the `terraform` images, only Checkov is configured by default
+1. Run a `checkov` security scan
+1. Run `terraform init`
+1. Identify if the filesystem changed, and only if so, run another `checkov` security scan
+1. Run `terraform apply -auto-approve`
 
 ### Learning mode
 
-The learning mode suppresses the exit codes of any injected validation or security tooling, ensuring the provided commands will run.  This can be
-configured by setting the `LEARNING_MODE` environment variable to `true`, for instance:
+The learning mode suppresses the exit codes of any injected validation or security tooling, ensuring the provided commands will run.  This can be configured by
+setting the `LEARNING_MODE` environment variable to `true`, for instance:
 
 ```bash
 docker run -e LEARNING_MODE=true -v $(pwd):/iac seiso/easy_infra:latest-terraform terraform apply -auto-approve

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -209,8 +209,6 @@ function {{ "scan_" ~ function if scan else function }}() {
     fi
 
     ## Only rerun security tools if (1) it is the first time, or (2) we are able to detect a change
-    bash: /tmp/terraform./iac.hash: No such file or directory
-
     dirs_to_hash=("${dir}")
   {%- if monitor is defined %}
     {%- for env_var in monitor["env_vars"] if monitor["env_vars"] %}

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -225,8 +225,8 @@ function {{ "scan_" ~ function if scan else function }}() {
       previous_hash="$(tail -1 "${hashfile}")"
     fi
     if [[ -r "${hashfile}" && -n ${hash} && ${hash} == "${previous_hash}" ]]; then
-      _feedback DEBUG "Setting run_scans to false because the hashfile already exists and the current hash matches the previous hash"
       run_scans="false"
+      _feedback DEBUG "Setting run_scans to ${run_scans} because the hashfile already exists and the current hash matches the previous hash"
     elif [[ -r "${hashfile}" ]]; then
       _feedback INFO "The files at ${dirs_to_hash[*]} were changed from ${previous_hash} to ${hash}; reactivating scans..."
       echo "${hash}" >> "${hashfile}"

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -209,6 +209,8 @@ function {{ "scan_" ~ function if scan else function }}() {
     fi
 
     ## Only rerun security tools if (1) it is the first time, or (2) we are able to detect a change
+    bash: /tmp/terraform./iac.hash: No such file or directory
+
     dirs_to_hash=("${dir}")
   {%- if monitor is defined %}
     {%- for env_var in monitor["env_vars"] if monitor["env_vars"] %}
@@ -218,8 +220,12 @@ function {{ "scan_" ~ function if scan else function }}() {
     {%- endfor %}
   {%- endif %}
     hash="$(sha256sum <(find ${dirs_to_hash[@]} -type f -exec sha256sum {} \; | sort) | awk '{print $1}')"
-    hashfile="/tmp/{{ function }}.${dir}.hash"
-    previous_hash="$(tail -1 "${hashfile}")"
+    sanitized_cwd="${dir//\//_}"
+    hashfile="/tmp/{{ function }}.${sanitized_cwd}.hash"
+    previous_hash='empty'
+    if [[ -r "${hashfile}" ]]; then
+      previous_hash="$(tail -1 "${hashfile}")"
+    fi
     if [[ -r "${hashfile}" && -n ${hash} && ${hash} == "${previous_hash}" ]]; then
       run_scans="false"
     elif [[ -r "${hashfile}" ]]; then

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -212,7 +212,7 @@ function {{ "scan_" ~ function if scan else function }}() {
     dirs_to_hash=("${dir}")
   {%- if monitor is defined %}
     {%- for env_var in monitor["env_vars"] if monitor["env_vars"] %}
-    if [[ -n {{ '${' }}{{ env_var }}}" ]]; then
+    if [[ -n {{ '${' }}{{ env_var }}} ]]; then
       dirs_to_hash+=("{{ '${' }}{{ env_var }}}")
     fi
     {%- endfor %}
@@ -223,11 +223,11 @@ function {{ "scan_" ~ function if scan else function }}() {
     if [[ -r "${hashfile}" && -n ${hash} && ${hash} == "${previous_hash}" ]]; then
       run_scans="false"
     elif [[ -r "${hashfile}" ]]; then
-      _feedback INFO "The files at ${dirs_to_hash[@]} were changed from ${previous_hash} to ${hash}; reactivating scans..."
+      _feedback INFO "The files at ${dirs_to_hash[*]} were changed from ${previous_hash} to ${hash}; reactivating scans..."
       echo "${hash}" >> "${hashfile}"
       run_scans="true"
     elif [[ -z ${hash} ]]; then
-      _feedback ERROR "Unable to obtain the hash of the files at ${dirs_to_hash[@]}; this should never happen"
+      _feedback ERROR "Unable to obtain the hash of the files at ${dirs_to_hash[*]}; this should never happen"
       exit 1
     else
       # This creates the hashfile

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -225,6 +225,7 @@ function {{ "scan_" ~ function if scan else function }}() {
       previous_hash="$(tail -1 "${hashfile}")"
     fi
     if [[ -r "${hashfile}" && -n ${hash} && ${hash} == "${previous_hash}" ]]; then
+      _feedback DEBUG "Setting run_scans to false because the hashfile already exists and the current hash matches the previous hash"
       run_scans="false"
     elif [[ -r "${hashfile}" ]]; then
       _feedback INFO "The files at ${dirs_to_hash[*]} were changed from ${previous_hash} to ${hash}; reactivating scans..."
@@ -234,6 +235,7 @@ function {{ "scan_" ~ function if scan else function }}() {
       _feedback ERROR "Unable to obtain the hash of the files at ${dirs_to_hash[*]}; this should never happen"
       exit 1
     else
+      _feedback DEBUG "Creating ${hashfile} with the contents ${hash} due to the files at ${dirs_to_hash[*]}"
       # This creates the hashfile
       echo "${hash}" >> "${hashfile}"
       run_scans="true"

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -55,6 +55,7 @@ function process_command_exit_status() {
 {%- set allow_filter = packages[package]["allow_filter"] -%}
 {%- set version_argument = packages[package]["version_argument"] -%}
 {%- set validations = packages[package]["validation"] -%}
+{%- set monitor = packages[package]["monitor"] -%}
 
 function {{ "scan_" ~ function if scan else function }}() {
   arguments=("${@}")
@@ -207,10 +208,38 @@ function {{ "scan_" ~ function if scan else function }}() {
       continue
     fi
 
+    ## Only rerun security tools if (1) it is the first time, or (2) we are able to detect a change
+    dirs_to_hash=("${dir}")
+  {%- if monitor is defined %}
+    {%- for env_var in monitor["env_vars"] if monitor["env_vars"] %}
+    if [[ -n {{ '${' }}{{ env_var }}}" ]]; then
+      dirs_to_hash+=("{{ '${' }}{{ env_var }}}")
+    fi
+    {%- endfor %}
+  {%- endif %}
+    hash="$(sha256sum <(find ${dirs_to_hash[@]} -type f -exec sha256sum {} \; | sort) | awk '{print $1}')"
+    hashfile="/tmp/{{ function }}.${dir}.hash"
+    previous_hash="$(tail -1 "${hashfile}")"
+    if [[ -r "${hashfile}" && -n ${hash} && ${hash} == "${previous_hash}" ]]; then
+      run_scans="false"
+    elif [[ -r "${hashfile}" ]]; then
+      _feedback INFO "The files at ${dirs_to_hash[@]} were changed from ${previous_hash} to ${hash}; reactivating scans..."
+      echo "${hash}" >> "${hashfile}"
+      run_scans="true"
+    elif [[ -z ${hash} ]]; then
+      _feedback ERROR "Unable to obtain the hash of the files at ${dirs_to_hash[@]}; this should never happen"
+      exit 1
+    else
+      # This creates the hashfile
+      echo "${hash}" >> "${hashfile}"
+      run_scans="true"
+    fi
+
   {%- if validations is defined %}
     ## Validate the input prior to running security tooling
     {%- for validation in validations %}
-    # If the initialization was already run successfully in a non-interactive shell with AUTODETECT not set to true, don't run it again
+    # If the initialization was already run successfully in a non-interactive shell with AUTODETECT not set to true,
+    # don't run it again
     if [[ -r "/tmp/{{ validation.command | replace(" ", "_") }}_complete" && "${AUTODETECT:-false}" != "true" ]]; then
       _feedback INFO "Skipping \`{{ validation.command }}\` because it was already run on $(date -d @"$(cat /tmp/{{ validation.command | replace(" ", "_") }}_complete)")"
     else
@@ -253,10 +282,11 @@ function {{ "scan_" ~ function if scan else function }}() {
     elif [[ "${!{{ security_tool | replace("-", "_") }}_skip_env_var,,}" == "true" ]]; then
       _feedback WARNING "Skipping {{ security_tool }} due to the {{ '${' }}{{ security_tool | replace("-", "_") }}_skip_env_var} environment variable value"
       _log "easy_infra.stdouterr" info unknown "{{ security_tool }}-skipped" "${dir}" string "Skipping {{ security_tool }} due to the {{ '${' }}{{ security_tool | replace("-", "_") }}_skip_env_var} environment variable value"
-    # If the security scan was already run successfully in a non-interactive shell with AUTODETECT not set to true, don't run it again
-    elif [[ -r "/tmp/{{ security_tool | replace("-", "_") }}_complete" && "${AUTODETECT:-false}" != "true" ]]; then
-      _feedback INFO "Skipping {{ security_tool }} because it was already run on $(date -d @"$(cat /tmp/{{ security_tool | replace("-", "_") }}_complete)")"
-      _log "easy_infra.stdouterr" info unknown "{{ security_tool }}-skipped" "${dir}" string "Skipping {{ security_tool }} because it was already run on $(date -d @"$(cat /tmp/{{ security_tool | replace("-", "_") }}_complete)")"
+    # If the security scan was already run successfully in a non-interactive shell and the filesystem hasn't changed
+    # since then, don't run it again
+    elif [[ ${run_scans:-true} == "false" && -r "/tmp/{{ security_tool | replace("-", "_") }}_complete" ]]; then
+      _feedback INFO "Skipping {{ security_tool }} because it was already run on $(date -d @"$(cat /tmp/{{ security_tool | replace("-", "_") }}_complete)") and the filesystem has not changed since then"
+      _log "easy_infra.stdouterr" info unknown "{{ security_tool }}-skipped" "${dir}" string "Skipping {{ security_tool }} because it was already run on $(date -d @"$(cat /tmp/{{ security_tool | replace("-", "_") }}_complete)") and the filesystem has not changed since then"
     # Otherwise, attempt to run the security tool
     else
       if [[ -x $(which {{ security_tool }}) ]]; then
@@ -342,8 +372,6 @@ function {{ "scan_" ~ function if scan else function }}() {
   done
 
   ## Process the exit codes from each directory
-  something_failed="false"
-
   for dir in "${!dir_exit_codes[@]}"; do
     if [[ "${dir_exit_codes[${dir}]}" -gt 0 ]]; then
       feedback_label="ERROR"

--- a/docs/Ansible/index.rst
+++ b/docs/Ansible/index.rst
@@ -64,4 +64,5 @@ The injected security tooling can be disabled entirely or individually, using ``
 Resources
 ---------
 
-Configuring custom checks can be done by leveraging the robust Rego language, maintained by the Open Policy Agent (OPA). OPA hosts `The Rego Playground <https://play.openpolicyagent.org/>`_ for testing custom rules written in Rego.
+Configuring custom checks can be done by leveraging the robust Rego language, maintained by the Open Policy Agent (OPA). OPA hosts `The Rego Playground
+<https://play.openpolicyagent.org/>`_ for testing custom rules written in Rego.

--- a/docs/CloudFormation/index.rst
+++ b/docs/CloudFormation/index.rst
@@ -77,4 +77,4 @@ Resources
 ---------
 
 Checkov allow numerous methods for creating custom policies, such as by writing them in Python or using the Checkov-specific DSL in yml files. These
-options are described in more detail `here <https://www.checkov.io/3.Custom%20Policies/Custom%20Policies%20Overview.html>_`
+options are described in more detail `here <https://www.checkov.io/3.Custom%20Policies/Custom%20Policies%20Overview.html>`_

--- a/docs/Technical Details/index.rst
+++ b/docs/Technical Details/index.rst
@@ -44,6 +44,9 @@ Here is a fictitious ``easy_infra.yml`` that concisely demonstrates the various 
         file_extensions: *id001
         helper: ["terraform"]
         security: *id002
+        monitor:
+          env_vars:
+            - TF_DATA_DIR
         tool:
           name: customname
           environments:
@@ -107,6 +110,16 @@ File extensions
 
 ``file_extensions`` exist to support the ``AUTODETECT`` function. If a ``package`` doesn't have file extensions defined, the project's autodetect
 logic is unable to detect where files that relate to the command being run exist.
+
+Monitor
+^^^^^^^
+
+The ``monitor`` section is how you can specify which additional locations on the filesystem we should monitor for
+changes to determine if we should rerun the security scans for instance, if ``AUTODETECT`` is ``true`` and you're
+running a command in multiple directories, and/or if you're chaining commands which may modify the filesystem. It
+currently only supports a ``env_vars`` key containing a list of strings, which are the names of environment variables
+that the related tool uses to identify alternative locations to store runtime-critical files. This may be expanded in
+the future.
 
 Security
 ^^^^^^^^

--- a/docs/Technical Details/index.rst
+++ b/docs/Technical Details/index.rst
@@ -115,11 +115,11 @@ Monitor
 ^^^^^^^
 
 The ``monitor`` section is how you can specify which additional locations on the filesystem we should monitor for
-changes to determine if we should rerun the security scans for instance, if ``AUTODETECT`` is ``true`` and you're
-running a command in multiple directories, and/or if you're chaining commands which may modify the filesystem. It
-currently only supports a ``env_vars`` key containing a list of strings, which are the names of environment variables
-that the related tool uses to identify alternative locations to store runtime-critical files. This may be expanded in
-the future.
+changes to determine if we should rerun the security scans. For instance, if ``AUTODETECT`` is ``true`` and you're
+running a command in multiple directories, and/or if you're chaining commands which may modify the filesystem.
+
+Monitor currently only supports a ``env_vars`` key containing a list of names of environment variables that the related
+tool uses to identify alternative locations to store runtime-critical files. This may be expanded in the future.
 
 Security
 ^^^^^^^^

--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -119,5 +119,5 @@ command (or series of commands) on all of them without needing to maintain a met
 Resources
 ---------
 
-Checkov allow numerous methods for creating custom policies, such as by writing them in Python or using the Checkov-specific DSL in yaml files. These
-options are described in more detail `here <https://www.checkov.io/3.Custom%20Policies/Custom%20Policies%20Overview.html>_`
+Checkov allow numerous methods for creating custom policies, such as by writing them in Python or using the Checkov-specific DSL in yaml files. These options
+are described in more detail `here <https://www.checkov.io/3.Custom%20Policies/Custom%20Policies%20Overview.html>`_

--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -9,6 +9,10 @@ environments as Infrastructure as Code (IaC).
 
 ``easy_infra`` uses security tools, such as `Checkov <https://www.checkov.io/>`_, to transparently assess the provided IaC against the defined security policy.
 
+.. warning::
+    ``easy_infra``'s `terraform` images are incompatable with the terraform ``-chdir`` argument as documented `here
+    <https://developer.hashicorp.com/terraform/cli/commands#switching-working-directory-with-chdir>`_.
+
 
 Use Cases
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,13 +5,3 @@
 
 
 .. mdinclude:: ../README.md
-
-.. toctree::
-   Home <self>
-   Terraform/index
-   CloudFormation/index
-   Ansible/index
-   Logging/index
-   Hooks/index
-   Cloning/index
-   Technical Details/index

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -10,11 +10,6 @@ _anchors:
         CHECKOV_EXTERNAL_CHECKS_DIR: --external-checks-dir
         CHECKOV_SKIP_CHECK: --skip-check
       description: directory scan
-  validation: &id004
-  - command: terraform init -backend=false
-    description: initialization
-  - command: terraform validate
-    description: validation
 environments:
   aws:
     packages:
@@ -84,8 +79,10 @@ packages:
     version_argument: version
   terraform:
     file_extensions: *id002
+    monitor:
+      env_vars:
+        - TF_DATA_DIR
     security: *id003
-    validation: *id004
     version: 1.4.6
     version_argument: version
   terratag:
@@ -100,6 +97,5 @@ packages:
     helper:
     - terraform
     security: *id003
-    validation: *id004
     version: v3.0.0
     version_argument: --version

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -96,6 +96,9 @@ packages:
     file_extensions: *id002
     helper:
     - terraform
+    monitor:
+      env_vars:
+        - TF_DATA_DIR
     security: *id003
     version: v3.0.0
     version_argument: --version

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -49,7 +49,7 @@ packages:
       environments:
       - none
       name: cloudformation
-    version: 2.11.19
+    version: 2.11.21
     version_argument: --version
   azure-cli:
     aliases:
@@ -57,12 +57,12 @@ packages:
     version: 2.48.1-1~focal
     version_argument: version
   checkov:
-    version: 2.3.237
+    version: 2.3.251
     version_argument: --version
   consul-template:
     helper:
     - all
-    version: v0.31.0
+    version: v0.32.0
     version_argument: --version
   envconsul:
     helper:
@@ -72,7 +72,7 @@ packages:
   fluent-bit:
     helper:
     - all
-    version: v2.1.2
+    version: v2.1.3
     version_argument: --version
   kics:
     version: v1.7.1
@@ -81,7 +81,7 @@ packages:
     file_extensions: *id002
     monitor:
       env_vars:
-        - TF_DATA_DIR
+      - TF_DATA_DIR
     security: *id003
     version: 1.4.6
     version_argument: version
@@ -98,7 +98,7 @@ packages:
     - terraform
     monitor:
       env_vars:
-        - TF_DATA_DIR
+      - TF_DATA_DIR
     security: *id003
     version: v3.0.0
     version_argument: --version

--- a/tests/test.py
+++ b/tests/test.py
@@ -1249,9 +1249,7 @@ def run_terraform(*, image: str, user: str) -> None:
     )
 
     # Running an interactive terraform command
-    test_interactive_container.exec_run(
-        cmd='/bin/bash -ic "terraform init"', tty=True
-    )
+    test_interactive_container.exec_run(cmd='/bin/bash -ic "terraform init"', tty=True)
 
     # An interactive terraform command should still cause the creation of the following files, and should have the same number of logs lines in the
     # fluent bit log regardless of which image is being tested

--- a/tests/test.py
+++ b/tests/test.py
@@ -737,7 +737,7 @@ def run_terraform(*, image: str, user: str) -> None:
     )
 
     # Ensure invalid configurations fail
-    command: str = "terraform plan"
+    command: str = "terraform init"
     LOG.debug("Testing invalid terraform configurations")
     utils.opinionated_docker_run(
         image=image,
@@ -902,7 +902,7 @@ def run_terraform(*, image: str, user: str) -> None:
     )
     for autodetect_status in ["true", "false"]:
         disable_security_and_autodetect_environment["AUTODETECT"] = autodetect_status
-        command = "terraform validate"
+        command = "terraform init"
 
         if autodetect_status == "true":
             # Expect exit 1 due to the discovery of terraform/general/invalid/invalid.tf
@@ -945,7 +945,7 @@ def run_terraform(*, image: str, user: str) -> None:
             )
 
         test_autodetect_disable_security_container.exec_run(
-            cmd='/bin/bash -c "terraform validate || true"', tty=False
+            cmd='/bin/bash -c "terraform init && terraform validate || true"', tty=False
         )
 
         if (
@@ -981,7 +981,7 @@ def run_terraform(*, image: str, user: str) -> None:
         ),  # Previous Terraform Caching example from the README.md
         (
             {},
-            '/usr/bin/env bash -c "terraform validate && terraform plan && terraform validate"',
+            '/usr/bin/env bash -c "terraform init && terraform validate && terraform plan && terraform validate"',
             0,
         ),
         (
@@ -1135,7 +1135,7 @@ def run_terraform(*, image: str, user: str) -> None:
         ),
         (
             {"DISABLE_SECURITY": "true"},
-            "terraform plan || false",
+            "terraform init || false",
             1,
         ),  # Not supported; reproduce "Too many command line arguments. Configuration path expected." error
         #     locally with `docker run -e DISABLE_SECURITY=true -v $(pwd)/tests/terraform/tool/checkov:/iac seiso/easy_infra:latest-terraform terraform plan
@@ -1164,32 +1164,32 @@ def run_terraform(*, image: str, user: str) -> None:
     # Ensure insecure configurations fail properly due to checkov
     # Tests is a list of tuples containing the test environment, command, and expected exit code
     tests: list[tuple[dict, str, int]] = [  # type: ignore
-        ({}, "terraform plan", 1),
+        ({}, "terraform init", 1),
         ({}, "tfenv exec plan", 1),
         ({}, "scan_terraform", 1),
         (
             {},
-            '/usr/bin/env bash -c "terraform plan"',
+            '/usr/bin/env bash -c "terraform init"',
             1,
         ),
         (
             {},
-            '/usr/bin/env bash -c "terraform plan || true"',
+            '/usr/bin/env bash -c "terraform init || true"',
             0,
         ),
         (
             {},
-            '/usr/bin/env bash -c "terraform plan || true && false"',
+            '/usr/bin/env bash -c "terraform init || true && false"',
             1,
         ),
         (
             {"LEARNING_MODE": "tRuE"},
-            '/usr/bin/env bash -c "terraform validate"',
+            '/usr/bin/env bash -c "terraform init && terraform validate"',
             0,
         ),
         (
             {"LEARNING_MODE": "tRuE"},
-            "terraform validate",
+            "terraform init",
             0,
         ),
     ]
@@ -1210,9 +1210,7 @@ def run_terraform(*, image: str, user: str) -> None:
     )
 
     # Running an interactive terraform command
-    test_interactive_container.exec_run(
-        cmd='/bin/bash -ic "terraform validate"', tty=True
-    )
+    test_interactive_container.exec_run(cmd='/bin/bash -ic "terraform init"', tty=True)
 
     # An interactive terraform command should not cause the creation of the following files, and should have the same number of logs lines in the
     # fluent bit log regardless of which image is being tested
@@ -1252,7 +1250,7 @@ def run_terraform(*, image: str, user: str) -> None:
 
     # Running an interactive terraform command
     test_interactive_container.exec_run(
-        cmd='/bin/bash -ic "terraform validate"', tty=True
+        cmd='/bin/bash -ic "terraform init"', tty=True
     )
 
     # An interactive terraform command should still cause the creation of the following files, and should have the same number of logs lines in the
@@ -1293,7 +1291,7 @@ def run_terraform(*, image: str, user: str) -> None:
 
     # Running a non-interactive terraform command
     test_noninteractive_container.exec_run(
-        cmd='/bin/bash -c "terraform validate"', tty=False
+        cmd='/bin/bash -c "terraform init"', tty=False
     )
 
     # A non-interactive terraform command should cause the creation of the following files, and should have the same number of logs lines in the
@@ -1337,7 +1335,7 @@ def run_terraform(*, image: str, user: str) -> None:
     # Running a non-interactive terraform version (or any other supported
     # "version" argument) should NOT cause the creation of the following files
     test_noninteractive_container.exec_run(
-        cmd='/bin/bash -c "terraform version"', tty=False
+        cmd='/bin/bash -c "terraform init"', tty=False
     )
     files = ["/tmp/checkov_complete"]
     LOG.debug("Testing non-interactive terraform version")

--- a/tests/test.py
+++ b/tests/test.py
@@ -945,7 +945,7 @@ def run_terraform(*, image: str, user: str) -> None:
             )
 
         test_autodetect_disable_security_container.exec_run(
-            cmd='/bin/bash -c "terraform init && terraform validate || true"', tty=False
+            cmd='/bin/bash -c "terraform init"', tty=False
         )
 
         if (

--- a/tests/test.py
+++ b/tests/test.py
@@ -1333,7 +1333,7 @@ def run_terraform(*, image: str, user: str) -> None:
     # Running a non-interactive terraform version (or any other supported
     # "version" argument) should NOT cause the creation of the following files
     test_noninteractive_container.exec_run(
-        cmd='/bin/bash -c "terraform init"', tty=False
+        cmd='/bin/bash -c "terraform version"', tty=False
     )
     files = ["/tmp/checkov_complete"]
     LOG.debug("Testing non-interactive terraform version")

--- a/tests/test.py
+++ b/tests/test.py
@@ -902,7 +902,7 @@ def run_terraform(*, image: str, user: str) -> None:
     )
     for autodetect_status in ["true", "false"]:
         disable_security_and_autodetect_environment["AUTODETECT"] = autodetect_status
-        command = "terraform init"
+        command = '/bin/bash -c "terraform init && terraform validate"'
 
         if autodetect_status == "true":
             # Expect exit 1 due to the discovery of terraform/general/invalid/invalid.tf
@@ -1189,7 +1189,7 @@ def run_terraform(*, image: str, user: str) -> None:
         ),
         (
             {"LEARNING_MODE": "tRuE"},
-            "terraform init",
+            '/bin/bash -c "terraform init && terraform validate"',
             0,
         ),
     ]


### PR DESCRIPTION
# Contributor Comments

This removes the previous `terraform init -backend=false && terraform validate` validation built-in and replaces it with dynamic filesystem monitoring to identify if files in the appropriate locations have changed, and only if they do change the scans are re-run, but if they do not change, scans are not re-run (only applies to non-interactive runs of easy_infra).  This is more accurate than the previous approach, which would run an `init` twice if you provided a single `terraform init`.

The previous `validation` logic is still available depending on the `easy_infra.yml` configuration, for future use as well as for forks of the project that may be leveraging this.  The documentation has been updated appropriately.

There is a BREAKING CHANGE in this approach; if you run a `terraform init` chained with any other `terraform` command, it will now:
1. Run the security tools
2. Run your provided `terraform init`
3. Re-run the security tools if your init changes the filesystem
4. Run your other `terraform` command(s) without re-running the security tools **only** if those commands don't also modify the filesystem.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
