### PR TITLE
chore: remove keys

### DIFF
--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -92,9 +92,8 @@ RUN groupadd --gid 53150 -r easy_infra \
    && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
    && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
    && mkdir /iac \
-   && chown -R easy_infra: /var/log/*.log /iac
-USER root
-RUN find /etc/ssh/ -type f -name '*key' -exec rm {} +
+   && chown -R easy_infra: /var/log/*.log /iac \
+   && find /etc/ssh/ -type f -name '*key' -exec rm {} +
 USER easy_infra
 
 COPY --chown=easy_infra:easy_infra functions /functions

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -30,71 +30,71 @@ ARG DEBIAN_FRONTEND="noninteractive"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3008,DL3013,SC1091
 RUN groupadd --gid 53150 -r easy_infra \
- && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
- && apt-get update \
- && apt-get -y install --no-install-recommends bsdmainutils \
-                                               ca-certificates \
-                                               curl \
-                                               gettext \
-                                               git \
-                                               groff \
-                                               jq \
-                                               less \
-                                               time \
-                                               tini \
- && apt-get -y upgrade \
- && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
- && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
- && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
- && apt-get -y install --no-install-recommends ssh \
- && ssh-keyscan gitlab.com \
-                github.com \
-                bitbucket.org \
-                ssh.dev.azure.com \
-                git-codecommit.us-east-1.amazonaws.com \
-                git-codecommit.us-east-2.amazonaws.com \
-                git-codecommit.us-west-1.amazonaws.com \
-                git-codecommit.us-west-2.amazonaws.com \
-    >> /home/easy_infra/.ssh/known_hosts \
- && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
- && apt-get remove -y ssh \
- # Remove ssh server keys to avoid Trivy secrets alert
- && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
- && mkdir -p /root/.ssh \
- && touch /root/.ssh/known_hosts \
- && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
- && if [ "${TRACE}" = "true" ]; then \
-    apt-get -y install --no-install-recommends libcap2-bin \
-                                               strace \
-  ; fi \
- && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
- && apt-get -y install --no-install-recommends unzip \
- && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
- && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
- && rm -f /usr/local/bin/consul-template.zip \
- && chmod 0755 /usr/local/bin/consul-template \
- && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
- && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
- && rm -f /usr/local/bin/envconsul.zip \
- && chmod 0755 /usr/local/bin/envconsul \
- && apt-get remove -y unzip \
- && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
- && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
- && cd fluent-bit/build \
- && cmake ../ && make && make install \
- && cd ../.. \
- && rm -rf fluent-bit \
- && apt-get remove -y cmake build-essential flex bison libssl-dev \
- && echo "source /functions" >> /home/easy_infra/.bashrc \
- && echo "source /functions" >> /root/.bashrc \
- && apt-get clean autoclean \
- && apt-get -y autoremove \
- # Must be after the autoremove for fluent-bit to work
- && apt-get remove -y libyaml-dev \
- && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
- && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
- && mkdir /iac \
- && chown -R easy_infra: /var/log/*.log /iac
+   && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
+   && apt-get update \
+   && apt-get -y install --no-install-recommends bsdmainutils \
+   ca-certificates \
+   curl \
+   gettext \
+   git \
+   groff \
+   jq \
+   less \
+   time \
+   tini \
+   && apt-get -y upgrade \
+   && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
+   && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
+   && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+   && apt-get -y install --no-install-recommends ssh \
+   && ssh-keyscan gitlab.com \
+   github.com \
+   bitbucket.org \
+   ssh.dev.azure.com \
+   git-codecommit.us-east-1.amazonaws.com \
+   git-codecommit.us-east-2.amazonaws.com \
+   git-codecommit.us-west-1.amazonaws.com \
+   git-codecommit.us-west-2.amazonaws.com \
+   >> /home/easy_infra/.ssh/known_hosts \
+   && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+   && apt-get remove -y ssh \
+   # Remove ssh server keys to avoid Trivy secrets alert
+   && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
+   && mkdir -p /root/.ssh \
+   && touch /root/.ssh/known_hosts \
+   && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
+   && if [ "${TRACE}" = "true" ]; then \
+   apt-get -y install --no-install-recommends libcap2-bin \
+   strace \
+   ; fi \
+   && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
+   && apt-get -y install --no-install-recommends unzip \
+   && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
+   && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
+   && rm -f /usr/local/bin/consul-template.zip \
+   && chmod 0755 /usr/local/bin/consul-template \
+   && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
+   && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
+   && rm -f /usr/local/bin/envconsul.zip \
+   && chmod 0755 /usr/local/bin/envconsul \
+   && apt-get remove -y unzip \
+   && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
+   && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
+   && cd fluent-bit/build \
+   && cmake ../ && make && make install \
+   && cd ../.. \
+   && rm -rf fluent-bit \
+   && apt-get remove -y cmake build-essential flex bison libssl-dev \
+   && echo "source /functions" >> /home/easy_infra/.bashrc \
+   && echo "source /functions" >> /root/.bashrc \
+   && apt-get clean autoclean \
+   && apt-get -y autoremove \
+   # Must be after the autoremove for fluent-bit to work
+   && apt-get remove -y libyaml-dev \
+   && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
+   && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
+   && mkdir /iac \
+   && chown -R easy_infra: /var/log/*.log /iac
 USER easy_infra
 
 COPY --chown=easy_infra:easy_infra functions /functions

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -30,71 +30,71 @@ ARG DEBIAN_FRONTEND="noninteractive"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3008,DL3013,SC1091
 RUN groupadd --gid 53150 -r easy_infra \
-   && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
-   && apt-get update \
-   && apt-get -y install --no-install-recommends bsdmainutils \
-   ca-certificates \
-   curl \
-   gettext \
-   git \
-   groff \
-   jq \
-   less \
-   time \
-   tini \
-   && apt-get -y upgrade \
-   && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
-   && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
-   && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
-   && apt-get -y install --no-install-recommends ssh \
-   && ssh-keyscan gitlab.com \
-   github.com \
-   bitbucket.org \
-   ssh.dev.azure.com \
-   git-codecommit.us-east-1.amazonaws.com \
-   git-codecommit.us-east-2.amazonaws.com \
-   git-codecommit.us-west-1.amazonaws.com \
-   git-codecommit.us-west-2.amazonaws.com \
-   >> /home/easy_infra/.ssh/known_hosts \
-   && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
-   && apt-get remove -y ssh \
-   # Remove ssh server keys to avoid Trivy secrets alert
-   && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
-   && mkdir -p /root/.ssh \
-   && touch /root/.ssh/known_hosts \
-   && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
-   && if [ "${TRACE}" = "true" ]; then \
-   apt-get -y install --no-install-recommends libcap2-bin \
-   strace \
-   ; fi \
-   && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
-   && apt-get -y install --no-install-recommends unzip \
-   && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
-   && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
-   && rm -f /usr/local/bin/consul-template.zip \
-   && chmod 0755 /usr/local/bin/consul-template \
-   && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
-   && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
-   && rm -f /usr/local/bin/envconsul.zip \
-   && chmod 0755 /usr/local/bin/envconsul \
-   && apt-get remove -y unzip \
-   && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
-   && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
-   && cd fluent-bit/build \
-   && cmake ../ && make && make install \
-   && cd ../.. \
-   && rm -rf fluent-bit \
-   && apt-get remove -y cmake build-essential flex bison libssl-dev \
-   && echo "source /functions" >> /home/easy_infra/.bashrc \
-   && echo "source /functions" >> /root/.bashrc \
-   && apt-get clean autoclean \
-   && apt-get -y autoremove \
-   # Must be after the autoremove for fluent-bit to work
-   && apt-get remove -y libyaml-dev \
-   && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
-   && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
-   && mkdir /iac \
-   && chown -R easy_infra: /var/log/*.log /iac
+ && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends bsdmainutils \
+                                               ca-certificates \
+                                               curl \
+                                               gettext \
+                                               git \
+                                               groff \
+                                               jq \
+                                               less \
+                                               time \
+                                               tini \
+ && apt-get -y upgrade \
+ && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
+ && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
+ && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+ && apt-get -y install --no-install-recommends ssh \
+ && ssh-keyscan gitlab.com \
+                github.com \
+                bitbucket.org \
+                ssh.dev.azure.com \
+                git-codecommit.us-east-1.amazonaws.com \
+                git-codecommit.us-east-2.amazonaws.com \
+                git-codecommit.us-west-1.amazonaws.com \
+                git-codecommit.us-west-2.amazonaws.com \
+    >> /home/easy_infra/.ssh/known_hosts \
+ && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+ && apt-get remove -y ssh \
+ # Remove ssh server keys to avoid Trivy secrets alert
+ && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
+ && mkdir -p /root/.ssh \
+ && touch /root/.ssh/known_hosts \
+ && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
+ && if [ "${TRACE}" = "true" ]; then \
+    apt-get -y install --no-install-recommends libcap2-bin \
+                                               strace \
+  ; fi \
+ && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
+ && apt-get -y install --no-install-recommends unzip \
+ && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
+ && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
+ && rm -f /usr/local/bin/consul-template.zip \
+ && chmod 0755 /usr/local/bin/consul-template \
+ && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
+ && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
+ && rm -f /usr/local/bin/envconsul.zip \
+ && chmod 0755 /usr/local/bin/envconsul \
+ && apt-get remove -y unzip \
+ && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
+ && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
+ && cd fluent-bit/build \
+ && cmake ../ && make && make install \
+ && cd ../.. \
+ && rm -rf fluent-bit \
+ && apt-get remove -y cmake build-essential flex bison libssl-dev \
+ && echo "source /functions" >> /home/easy_infra/.bashrc \
+ && echo "source /functions" >> /root/.bashrc \
+ && apt-get clean autoclean \
+ && apt-get -y autoremove \
+ # Must be after the autoremove for fluent-bit to work
+ && apt-get remove -y libyaml-dev \
+ && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
+ && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
+ && mkdir /iac \
+ && chown -R easy_infra: /var/log/*.log /iac
 USER easy_infra
 
 COPY --chown=easy_infra:easy_infra functions /functions

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -30,69 +30,71 @@ ARG DEBIAN_FRONTEND="noninteractive"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3008,DL3013,SC1091
 RUN groupadd --gid 53150 -r easy_infra \
- && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
- && apt-get update \
- && apt-get -y install --no-install-recommends bsdmainutils \
-                                               ca-certificates \
-                                               curl \
-                                               gettext \
-                                               git \
-                                               groff \
-                                               jq \
-                                               less \
-                                               time \
-                                               tini \
- && apt-get -y upgrade \
- && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
- && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
- && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
- && apt-get -y install --no-install-recommends ssh \
- && ssh-keyscan gitlab.com \
-                github.com \
-                bitbucket.org \
-                ssh.dev.azure.com \
-                git-codecommit.us-east-1.amazonaws.com \
-                git-codecommit.us-east-2.amazonaws.com \
-                git-codecommit.us-west-1.amazonaws.com \
-                git-codecommit.us-west-2.amazonaws.com \
-    >> /home/easy_infra/.ssh/known_hosts \
- && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
- && apt-get remove -y ssh \
- && mkdir -p /root/.ssh \
- && touch /root/.ssh/known_hosts \
- && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
- && if [ "${TRACE}" = "true" ]; then \
-    apt-get -y install --no-install-recommends libcap2-bin \
-                                               strace \
-  ; fi \
- && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
- && apt-get -y install --no-install-recommends unzip \
- && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
- && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
- && rm -f /usr/local/bin/consul-template.zip \
- && chmod 0755 /usr/local/bin/consul-template \
- && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
- && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
- && rm -f /usr/local/bin/envconsul.zip \
- && chmod 0755 /usr/local/bin/envconsul \
- && apt-get remove -y unzip \
- && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
- && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
- && cd fluent-bit/build \
- && cmake ../ && make && make install \
- && cd ../.. \
- && rm -rf fluent-bit \
- && apt-get remove -y cmake build-essential flex bison libssl-dev \
- && echo "source /functions" >> /home/easy_infra/.bashrc \
- && echo "source /functions" >> /root/.bashrc \
- && apt-get clean autoclean \
- && apt-get -y autoremove \
- # Must be after the autoremove for fluent-bit to work
- && apt-get remove -y libyaml-dev \
- && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
- && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
- && mkdir /iac \
- && chown -R easy_infra: /var/log/*.log /iac
+   && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
+   && apt-get update \
+   && apt-get -y install --no-install-recommends bsdmainutils \
+   ca-certificates \
+   curl \
+   gettext \
+   git \
+   groff \
+   jq \
+   less \
+   time \
+   tini \
+   && apt-get -y upgrade \
+   && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
+   && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
+   && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+   && apt-get -y install --no-install-recommends ssh \
+   && ssh-keyscan gitlab.com \
+   github.com \
+   bitbucket.org \
+   ssh.dev.azure.com \
+   git-codecommit.us-east-1.amazonaws.com \
+   git-codecommit.us-east-2.amazonaws.com \
+   git-codecommit.us-west-1.amazonaws.com \
+   git-codecommit.us-west-2.amazonaws.com \
+   >> /home/easy_infra/.ssh/known_hosts \
+   && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+   && apt-get remove -y ssh \
+   && mkdir -p /root/.ssh \
+   && touch /root/.ssh/known_hosts \
+   && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
+   && if [ "${TRACE}" = "true" ]; then \
+   apt-get -y install --no-install-recommends libcap2-bin \
+   strace \
+   ; fi \
+   && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
+   && apt-get -y install --no-install-recommends unzip \
+   && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
+   && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
+   && rm -f /usr/local/bin/consul-template.zip \
+   && chmod 0755 /usr/local/bin/consul-template \
+   && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
+   && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
+   && rm -f /usr/local/bin/envconsul.zip \
+   && chmod 0755 /usr/local/bin/envconsul \
+   && apt-get remove -y unzip \
+   && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
+   && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
+   && cd fluent-bit/build \
+   && cmake ../ && make && make install \
+   && cd ../.. \
+   && rm -rf fluent-bit \
+   && apt-get remove -y cmake build-essential flex bison libssl-dev \
+   && echo "source /functions" >> /home/easy_infra/.bashrc \
+   && echo "source /functions" >> /root/.bashrc \
+   && apt-get clean autoclean \
+   && apt-get -y autoremove \
+   # Must be after the autoremove for fluent-bit to work
+   && apt-get remove -y libyaml-dev \
+   && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
+   && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
+   && mkdir /iac \
+   && chown -R easy_infra: /var/log/*.log /iac
+USER root
+RUN find /etc/ssh/ -type f -name '*key' -exec rm {} +
 USER easy_infra
 
 COPY --chown=easy_infra:easy_infra functions /functions

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -30,71 +30,71 @@ ARG DEBIAN_FRONTEND="noninteractive"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3008,DL3013,SC1091
 RUN groupadd --gid 53150 -r easy_infra \
-   && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
-   && apt-get update \
-   && apt-get -y install --no-install-recommends bsdmainutils \
-   ca-certificates \
-   curl \
-   gettext \
-   git \
-   groff \
-   jq \
-   less \
-   time \
-   tini \
-   && apt-get -y upgrade \
-   && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
-   && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
-   && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
-   && apt-get -y install --no-install-recommends ssh \
-   && ssh-keyscan gitlab.com \
-   github.com \
-   bitbucket.org \
-   ssh.dev.azure.com \
-   git-codecommit.us-east-1.amazonaws.com \
-   git-codecommit.us-east-2.amazonaws.com \
-   git-codecommit.us-west-1.amazonaws.com \
-   git-codecommit.us-west-2.amazonaws.com \
-   >> /home/easy_infra/.ssh/known_hosts \
-   && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
-   && apt-get uninstall -y ssh \
-   # Remove ssh server keys to avoid Trivy secrets alert
-   && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
-   && mkdir -p /root/.ssh \
-   && touch /root/.ssh/known_hosts \
-   && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
-   && if [ "${TRACE}" = "true" ]; then \
-   apt-get -y install --no-install-recommends libcap2-bin \
-   strace \
-   ; fi \
-   && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
-   && apt-get -y install --no-install-recommends unzip \
-   && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
-   && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
-   && rm -f /usr/local/bin/consul-template.zip \
-   && chmod 0755 /usr/local/bin/consul-template \
-   && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
-   && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
-   && rm -f /usr/local/bin/envconsul.zip \
-   && chmod 0755 /usr/local/bin/envconsul \
-   && apt-get remove -y unzip \
-   && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
-   && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
-   && cd fluent-bit/build \
-   && cmake ../ && make && make install \
-   && cd ../.. \
-   && rm -rf fluent-bit \
-   && apt-get remove -y cmake build-essential flex bison libssl-dev \
-   && echo "source /functions" >> /home/easy_infra/.bashrc \
-   && echo "source /functions" >> /root/.bashrc \
-   && apt-get clean autoclean \
-   && apt-get -y autoremove \
-   # Must be after the autoremove for fluent-bit to work
-   && apt-get remove -y libyaml-dev \
-   && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
-   && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
-   && mkdir /iac \
-   && chown -R easy_infra: /var/log/*.log /iac
+ && useradd -r -g easy_infra -s "$(which bash)" --create-home --uid 53150 easy_infra \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends bsdmainutils \
+                                               ca-certificates \
+                                               curl \
+                                               gettext \
+                                               git \
+                                               groff \
+                                               jq \
+                                               less \
+                                               time \
+                                               tini \
+ && apt-get -y upgrade \
+ && su - easy_infra -c "mkdir -p /home/easy_infra/.ssh" \
+ && su - easy_infra -c "touch /home/easy_infra/.ssh/known_hosts" \
+ && echo "# START preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+ && apt-get -y install --no-install-recommends ssh \
+ && ssh-keyscan gitlab.com \
+                github.com \
+                bitbucket.org \
+                ssh.dev.azure.com \
+                git-codecommit.us-east-1.amazonaws.com \
+                git-codecommit.us-east-2.amazonaws.com \
+                git-codecommit.us-west-1.amazonaws.com \
+                git-codecommit.us-west-2.amazonaws.com \
+    >> /home/easy_infra/.ssh/known_hosts \
+ && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
+ && apt-get remove -y ssh \
+ # Remove ssh server keys to avoid Trivy secrets alert
+ && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
+ && mkdir -p /root/.ssh \
+ && touch /root/.ssh/known_hosts \
+ && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
+ && if [ "${TRACE}" = "true" ]; then \
+    apt-get -y install --no-install-recommends libcap2-bin \
+                                               strace \
+  ; fi \
+ && su easy_infra -c "mkdir -p /home/easy_infra/.local/bin/" \
+ && apt-get -y install --no-install-recommends unzip \
+ && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION#v}/consul-template_${CONSUL_TEMPLATE_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/consul-template.zip \
+ && unzip /usr/local/bin/consul-template.zip -d /usr/local/bin/ \
+ && rm -f /usr/local/bin/consul-template.zip \
+ && chmod 0755 /usr/local/bin/consul-template \
+ && curl -L https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION#v}/envconsul_${ENVCONSUL_VERSION#v}_linux_${BUILDARCH}.zip -o /usr/local/bin/envconsul.zip \
+ && unzip /usr/local/bin/envconsul.zip -d /usr/local/bin/ \
+ && rm -f /usr/local/bin/envconsul.zip \
+ && chmod 0755 /usr/local/bin/envconsul \
+ && apt-get remove -y unzip \
+ && apt-get install -y --no-install-recommends cmake build-essential flex bison libyaml-dev libssl-dev \
+ && git clone https://github.com/fluent/fluent-bit --depth 1 --branch ${FLUENT_BIT_VERSION} \
+ && cd fluent-bit/build \
+ && cmake ../ && make && make install \
+ && cd ../.. \
+ && rm -rf fluent-bit \
+ && apt-get remove -y cmake build-essential flex bison libssl-dev \
+ && echo "source /functions" >> /home/easy_infra/.bashrc \
+ && echo "source /functions" >> /root/.bashrc \
+ && apt-get clean autoclean \
+ && apt-get -y autoremove \
+ # Must be after the autoremove for fluent-bit to work
+ && apt-get remove -y libyaml-dev \
+ && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
+ && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
+ && mkdir /iac \
+ && chown -R easy_infra: /var/log/*.log /iac
 USER easy_infra
 
 COPY --chown=easy_infra:easy_infra functions /functions

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -57,7 +57,9 @@ RUN groupadd --gid 53150 -r easy_infra \
    git-codecommit.us-west-2.amazonaws.com \
    >> /home/easy_infra/.ssh/known_hosts \
    && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
-   && apt-get remove -y ssh \
+   && apt-get uninstall -y ssh \
+   # Remove ssh server keys to avoid Trivy secrets alert
+   && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
    && mkdir -p /root/.ssh \
    && touch /root/.ssh/known_hosts \
    && cp /home/easy_infra/.ssh/known_hosts /root/.ssh/known_hosts \
@@ -92,8 +94,7 @@ RUN groupadd --gid 53150 -r easy_infra \
    && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/* /var/cache/debconf/*-old \
    && touch /var/log/easy_infra.log /var/log/fluent-bit.log /var/log/40-set_default_terraform_version.log /var/log/50-terraform_dynamic_version_use.log /var/log/clone.log /var/log/clone.err.log \
    && mkdir /iac \
-   && chown -R easy_infra: /var/log/*.log /iac \
-   && find /etc/ssh/ -type f -name '*key' -exec rm {} +
+   && chown -R easy_infra: /var/log/*.log /iac
 USER easy_infra
 
 COPY --chown=easy_infra:easy_infra functions /functions

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -58,7 +58,7 @@ RUN groupadd --gid 53150 -r easy_infra \
     >> /home/easy_infra/.ssh/known_hosts \
  && echo "# END preloaded known_hosts as of $(date)" >> /home/easy_infra/.ssh/known_hosts \
  && apt-get remove -y ssh \
- # Remove ssh server keys to avoid Trivy secrets alert
+ # The apt-get install ssh generates keys that are unnecessary/unused and get flagged in secrets scans. They aren’t auto cleaned up with an apt-get remove or purge
  && find /etc/ssh/ -type f -name '*key' -exec rm {} + \
  && mkdir -p /root/.ssh \
  && touch /root/.ssh/known_hosts \


### PR DESCRIPTION
# Contributor Comments

Installing SSH automatically generates sets of SSH keys for the server. The existence of private keys in the container triggers a Trivy alert. This code addition removes the unused keys from the easy_infra image.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
