### PR TITLE
feat: support scan_ function hooks

### DIFF
--- a/build/functions.j2
+++ b/build/functions.j2
@@ -116,7 +116,7 @@ function {{ "scan_" ~ function if scan else function }}() {
     # Dynamically register hooks
     for file in /opt/hooks/bin/*.sh; do
       command=$(awk -F\: '/register_hook/ { gsub(/ /,""); print $2 }' "${file}")
-      if [[ "${command}" == "{{ function }}" ]]; then
+      if [[ "${command}" == "{{ 'scan_' ~ function if scan else function }}" ]]; then
         easy_infra_{{ function | replace("-", "_") }}_hooks+=("${file}")
       fi
     done

--- a/docs/Hooks/index.rst
+++ b/docs/Hooks/index.rst
@@ -15,7 +15,9 @@ like to hook::
     # register_hook: terraform
 
 .. note::
-    Only packages (or their related aliases, where specified) listed in ``easy_infra.yml`` at build time are supported. This means that, if a package has multiple aliases it will need to be registered against each of those aliases.
+    Only packages or their related aliases listed in ``easy_infra.yml`` at build time, or the ``scan_`` functions (which only perform the security scans, i.e.
+    ``scan_terraform`` or ``scan_cloudformation``) are supported. This means that, if a package has multiple aliases, or if you'd like to support the ``scan_``
+    function, you will need to be registered your hook against each of those.
 
 Example
 ^^^^^^^

--- a/docs/Technical Details/index.rst
+++ b/docs/Technical Details/index.rst
@@ -243,13 +243,20 @@ Internal naming
   above), as configured in the ``easy_infra.yml`` file used to build the image.
 - Package: The name of a package that can be installed to perform a necessary function. It could be a tool, a security tool, or a generic helper such
   as ``fluent-bit`` or ``envconsul``.
-- Command: A runtime command, following the use of the term by bash (see the "Command Execution" of this documentation). This could be an alias, a
-  package, or some other executable on the user's ``PATH``.
+- Command: A runtime command, following the use of the term by bash (see `this documentation<https://www.ibm.com/docs/en/aix/7.2?topic=c-command-command>`_).
+  This could be an alias, a package, or some other executable on the user's ``PATH``.
 - Alias: An executable file in the easy_infra and root user's ``PATH`` which executes the installed by a package. While ``aws-cli`` would be a package, ``aws``
   would be the associated alias.
 - Environment: A supported destination that a tool (see above) may deploy into, such as a cloud provider. An environment constitutes a bundle of
   packages.
 
+Scan-only functions
+===================
+
+In addition to the Alias and Package functions which are generated, ``scan_`` functions are also created to allow you to run only the security scans (and
+related hooks) for a given Package or Alias. So, for instance, if you have a Package of ``terraform``, the related scan function would be ``scan_terraform``.
+Whereas, if you have a Package of ``ansible`` which has Aliases of ``ansible`` and ``ansible-playbook``, you will get scan functions of ``scan_ansible`` and
+``scan_ansible-playbook``.
 
 High-Level Design of the image build process
 ============================================
@@ -280,9 +287,9 @@ build on top of ``Dockerfile.abc``, and it is both expected that in ``Dockerfrag
 Runtime user support
 ====================
 
-By default, ``easy_infra`` runs as the ``easy_infra`` user and should be fully functional, however we also support the
-``root`` user due to various file system permission issues that often occur in pipelines when running as non-root users.
-Where possible, the ``easy_infra`` user should be used due to the security risks of running containers as ``root``.
+By default, ``easy_infra`` runs as the ``easy_infra`` user and should be fully functional, however we also support the ``root`` user due to various file system
+permission issues that often occur in pipelines when running as non-root users. Where possible, the ``easy_infra`` user should be used due to the security risks
+of running containers as ``root``.
 
 Adding to the project
 =====================


### PR DESCRIPTION
# Contributor Comments

This allows you to register hooks against the generated `scan_` functions, meaning that you can now arbitrarily register and run hooks against a repo or set of repos without needing to create a valid Command, you can simply write a hook for `scan_ansible` and then run `scan_ansible` against a repo to have the hook run, generate logs, and centralize them using your existing `fluent-bit` configs.

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [ ] Rebase your branch against the latest commit of the target branch
- [ ] If you are adding a dependency, please explain how it was chosen
- [ ] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [ ] If there is an issue associated with your Pull Request, link the issue to the PR.
