### PR TITLE
ci: only retest with the default runtime user

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -194,7 +194,8 @@ jobs:
       - name: Run tests
         run: |
           find tests -mindepth 1 -type d -exec chmod o+w {} \;
-          pipenv run invoke test --tool=${{ matrix.tool }} --environment=${{ matrix.environment }} --user=${{ matrix.user }} --debug
+          # We only test with the easy_infra user here; all supported users are tested via the PR workflow
+          pipenv run invoke test --tool=${{ matrix.tool }} --environment=${{ matrix.environment }} --user=easy_infra --debug
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
# Contributor Comments

If you don't specify a `--user`, it will test with all supported users in parallel, which currently would take an additional 10 minutes. This specifies the default user of `easy_infra` during the `distribute` step's testing, because this is just a retest of an already fully tested repo (as a part of `test` on PR).

## Pull Request Checklist

Thank you for submitting a contribution to `easy_infra`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [ ] Rebase your branch against the latest commit of the target branch
- [ ] If you are adding a dependency, please explain how it was chosen
- [ ] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [ ] If there is an issue associated with your Pull Request, link the issue to the PR.
