### PR TITLE
test: generate SBOMs automatically when needed

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -202,13 +202,6 @@ jobs:
         env:
           TOOL: ${{ matrix.tool }}
           ENVIRONMENT: ${{ matrix.environment }}
-      - name: Run tests
-        run: task -v test
-        env:
-          TOOL: ${{ matrix.tool }}
-          ENVIRONMENT: ${{ matrix.environment }}
-          USER: ${{ matrix.user }}
-          DEBUG: "True"
       - name: Generate the SBOM
         run: task -v sbom
         env:
@@ -231,6 +224,13 @@ jobs:
           name: Vulns_${{ matrix.tool }}_${{ matrix.environment }}
           path: vulns.*.json
           if-no-files-found: error
+      - name: Run tests
+        run: task -v test
+        env:
+          TOOL: ${{ matrix.tool }}
+          ENVIRONMENT: ${{ matrix.environment }}
+          USER: ${{ matrix.user }}
+          DEBUG: "True"
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/easy_infra/utils.py
+++ b/easy_infra/utils.py
@@ -1068,39 +1068,6 @@ def test(tool="all", environment="all", user="all", debug=False) -> None:
                 user=user,
             )
 
-            if os.getenv("GITHUB_ACTIONS") != "true":
-                continue
-
-            # See the warning under https://docs.python.org/3/library/subprocess.html#popen-constructor and some additional context in
-            # https://github.com/python/cpython/issues/105889
-            if (task_absolute_path := shutil.which("task")) is None:
-                LOG.error("Unable to find task in your PATH")
-                sys.exit(1)
-
-            # Cleanup after test runs in a pipeline
-            try:
-                env: dict[str, str] = os.environ.copy()
-                LOG.debug(f"{env=}")
-                # https://unix.stackexchange.com/a/83194/28597 and https://manpages.ubuntu.com/manpages/focal/en/man8/sudo.8.html#environment are good
-                # references
-                command: str = (
-                    f"sudo env PATH='{env['PATH']}' {task_absolute_path} -v clean"
-                )
-                out = subprocess.run(
-                    command,
-                    capture_output=True,
-                    check=True,
-                    shell=True,
-                )
-                LOG.debug(
-                    f"stdout: {out.stdout.decode('UTF-8')}, stderr: {out.stderr.decode('UTF-8')}"
-                )
-            except subprocess.CalledProcessError as error:
-                LOG.error(
-                    f"stdout: {error.stdout.decode('UTF-8')}, stderr: {error.stderr.decode('UTF-8')}"
-                )
-                sys.exit(1)
-
 
 def vulnscan(tool="all", environment="all", debug=False) -> None:
     """Scan easy_infra for vulns"""
@@ -1116,7 +1083,7 @@ def vulnscan(tool="all", environment="all", debug=False) -> None:
     )
 
     for tag in tags:
-        run_test.run_security(tag=tag)
+        run_test.run_security(tool=tool, environment=environment, tag=tag)
 
 
 def publish(tool="all", environment="all", debug=False, dry_run=False) -> None:


### PR DESCRIPTION
# Contributor Comments

Previously when we run `run_security` it would fail if the SBOM didn't exist; now it just runs the `sbom` function to create it and then continues.

Also, we relocate the `task -v clean` task

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: https://www.wrike.com/open.htm?id=1193552638
-->