### PR TITLE
fix: add checkov output to stdout in case of failed findings

### DIFF
--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -4,7 +4,7 @@ _anchors:
   security: &id003
     checkov:
       command: checkov -d . --download-external-modules True --framework terraform
-        --skip-download --output json --output-file-path ${CHECKOV_JSON_REPORT_PATH}/checkov.json,
+        --skip-download --output cli --output json --output-file-path console,${CHECKOV_JSON_REPORT_PATH}/checkov.json
       customizations: &id001
         CHECKOV_BASELINE: --baseline
         CHECKOV_EXTERNAL_CHECKS_DIR: --external-checks-dir
@@ -41,8 +41,8 @@ packages:
       position: 0
     security:
       checkov:
-        command: checkov -d . --framework cloudformation --skip-download --output
-          json --output-file-path ${CHECKOV_JSON_REPORT_PATH}/checkov.json,
+        command: checkov -d . --framework cloudformation --skip-download --output cli
+          --output json --output-file-path console,${CHECKOV_JSON_REPORT_PATH}/checkov.json
         customizations: *id001
         description: directory scan
     tool:


### PR DESCRIPTION
# Contributor Comments

Previously, you would only see this output when a `checkov` scan failed:

```bash
2023-09-13T14:46:18+00:00 - INFO:  Changing into the /iac directory...
2023-09-13T14:46:20+00:00 - ERROR:  Failed checkov directory scan
2023-09-13T14:46:20+00:00 - ERROR:  /iac resulted in an exit code of 1
```

Now, sandwiched between the two errors you see the checkov outputs.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [ ] Rebase your branch against the latest commit of the target branch.
- [ ] If you are adding a dependency, please explain how it was chosen.
- [ ] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [ ] If there is an issue associated with your Pull Request, link the issue to the PR.
- [ ] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: [replace this text with permalink URL] 
-->