### PR TITLE
fix: adding support for dynamic mounting dir

### DIFF
--- a/build/functions.j2
+++ b/build/functions.j2
@@ -123,9 +123,10 @@ function {{ "scan_" ~ function if scan else function }}() {
   fi
 
   # This attempts to detect a .git directory in the work dir and adds it as a safe directory to prevent errors when generating git context for logs.
+  rootdir=$(pwd -P)
   export GIT_CONFIG_COUNT=1
   export GIT_CONFIG_KEY_0="safe.directory"
-  GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo /iac)"
+  GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${rootdir})"
   export GIT_CONFIG_VALUE_0
 
   # Methods to skip **all** security tools for {{ function }}{% for filter in allow_filter if allow_filter is defined %} {{ filter['match'] }}{% endfor %}
@@ -156,7 +157,7 @@ function {{ "scan_" ~ function if scan else function }}() {
     pushd "${dir}" > /dev/null
 
     # Keep the git config value aligned with the current directory
-    GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo /iac)"
+    GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${rootdir})"
 
     # Export variables to be used in the hooks
     export dir

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -58,6 +58,7 @@ function process_command_exit_status() {
 {%- set monitor = packages[package]["monitor"] -%}
 
 function {{ "scan_" ~ function if scan else function }}() {
+  _feedback DEBUGGING "Entering the ${FUNCNAME[0]} function..."
   arguments=("${@}")
   easy_infra_{{ function | replace("-", "_") }}_security_tools=({% for security_tool in security_tools %}{{ security_tool | replace("-", "_") }}{% if not loop.last %} {% endif %}{% endfor %})
 
@@ -117,26 +118,32 @@ function {{ "scan_" ~ function if scan else function }}() {
     for file in /opt/hooks/bin/*.sh; do
       command=$(awk -F\: '/register_hook/ { gsub(/ /,""); print $2 }' "${file}")
       if [[ "${command}" == "{{ 'scan_' ~ function if scan else function }}" ]]; then
+        _feedback DEBUGGING "Registering ${file} to the ${FUNCNAME[0]} hooks"
         easy_infra_{{ function | replace("-", "_") }}_hooks+=("${file}")
       fi
     done
   fi
 
-  # This attempts to detect a .git directory in the work dir and adds it as a safe directory to prevent errors when generating git context for logs.
+  # Adds the detected git toplevel as a safe directory to prevent errors when generating git context for logs.
   current_dir=$(pwd -P)
   export GIT_CONFIG_COUNT=1
+  _feedback DEBUGGING "Set GIT_CONFIG_COUNT to ${GIT_CONFIG_COUNT}"
   export GIT_CONFIG_KEY_0="safe.directory"
+  _feedback DEBUGGING "Set GIT_CONFIG_KEY_0 to ${GIT_CONFIG_KEY_0}"
   GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${current_dir})"
   export GIT_CONFIG_VALUE_0
+  _feedback DEBUGGING "Set GIT_CONFIG_VALUE_0 to ${GIT_CONFIG_VALUE_0}"
 
   # Methods to skip **all** security tools for {{ function }}{% for filter in allow_filter if allow_filter is defined %} {{ filter['match'] }}{% endfor %}
   DISABLE_SECURITY="${DISABLE_SECURITY:-false}"
   dirs=()
+  _feedback DEBUGGING "AUTODETECT is ${AUTODETECT:-not set}"
   if [[ "${AUTODETECT:-false}" == "true" ]]; then
 {%- if file_extensions is defined %}
 {%- for file_extension in file_extensions %}
     files=$(find . -iname "*.{{ file_extension }}" -type f)
     if [[ "${files}" ]]; then
+      _feedback DEBUGGING "Adding to the dirs loop due to detecting files with the {{ file_extension }} extension: ${files}"
       dirs+=($(for file in ${files}; do dirname ${file}; done | sort -u | xargs readlink --canonicalize))
     fi
 {%- endfor %}
@@ -149,6 +156,7 @@ function {{ "scan_" ~ function if scan else function }}() {
   else
     dirs+=($(pwd -P))
   fi
+  _feedback DEBUGGING "The final dirs array is ${dirs[*]:-empty}"
 
   declare -A dir_exit_codes
 

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -123,10 +123,10 @@ function {{ "scan_" ~ function if scan else function }}() {
   fi
 
   # This attempts to detect a .git directory in the work dir and adds it as a safe directory to prevent errors when generating git context for logs.
-  rootdir=$(pwd -P)
+  current_dir=$(pwd -P)
   export GIT_CONFIG_COUNT=1
   export GIT_CONFIG_KEY_0="safe.directory"
-  GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${rootdir})"
+  GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${current_dir})"
   export GIT_CONFIG_VALUE_0
 
   # Methods to skip **all** security tools for {{ function }}{% for filter in allow_filter if allow_filter is defined %} {{ filter['match'] }}{% endfor %}
@@ -157,7 +157,7 @@ function {{ "scan_" ~ function if scan else function }}() {
     pushd "${dir}" > /dev/null
 
     # Keep the git config value aligned with the current directory
-    GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${rootdir})"
+    GIT_CONFIG_VALUE_0="$(git rev-parse --show-toplevel 2>/dev/null || echo ${current_dir})"
 
     # Export variables to be used in the hooks
     export dir

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -159,8 +159,8 @@ function {{ "scan_" ~ function if scan else function }}() {
 
   declare -A dir_exit_codes
 
-  if [ ${#dirs[@]} -eq 0 ]; then
-    _feedback WARNING "No directories to iterate through; did you set AUTODETECT=true on a repo with no matching file extensions?"
+  if [ "{{ '${' }}#dirs[@]}" -eq 0 ]; then
+    _feedback WARNING "The function ${FUNCNAME[0]} has no directories to iterate through; did you run ${FUNCNAME[0]} with AUTODETECT=true but with no matching files in any subdirectories?"
   else
     _feedback DEBUGGING "The final dirs array is ${dirs[*]:-empty}"
   fi

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -156,9 +156,14 @@ function {{ "scan_" ~ function if scan else function }}() {
   else
     dirs+=($(pwd -P))
   fi
-  _feedback DEBUGGING "The final dirs array is ${dirs[*]:-empty}"
 
   declare -A dir_exit_codes
+
+  if [ ${#dirs[@]} -eq 0 ]; then
+    _feedback WARNING "No directories to iterate through; did you set AUTODETECT=true on a repo with no matching file extensions?"
+  else
+    _feedback DEBUGGING "The final dirs array is ${dirs[*]:-empty}"
+  fi
 
   for dir in "${dirs[@]}"; do
     _feedback INFO "Changing into the ${dir} directory..."

--- a/tests/test.py
+++ b/tests/test.py
@@ -1481,7 +1481,11 @@ def run_ansible(*, image: str, user: str) -> None:
     # Test alternative working directories/binds
     # Tests is a list of tuples containing the test environment, command, and expected exit code
     tests: list[tuple[dict, str, int]] = [  # type: ignore
-        ({}, "ansible-playbook secure.yml --syntax-check", 0),
+        (
+            {},
+            "ansible-playbook secure.yml --syntax-check",
+            4,
+        ),  # Exits 4 because secure.yml is not a valid Play
         ({}, '/bin/bash -c "ansible-playbook secure.yml --syntax-check && false"', 1),
     ]
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1486,7 +1486,7 @@ def run_ansible(*, image: str, user: str) -> None:
             "ansible-playbook secure.yml --syntax-check",
             4,
         ),  # Exits 4 because secure.yml is not a valid Play
-        ({}, '/bin/bash -c "ansible-playbook secure.yml --syntax-check && false"', 1),
+        ({}, '/bin/bash -c "ansible-playbook secure.yml --syntax-check || false"', 1),
     ]
 
     LOG.debug("Testing alternative working dirs/binds with the ansible image")


### PR DESCRIPTION
# Contributor Comments

This PR fixes a bug in setting the top level directory for GIT_CONFIG_VALUE_0, which is used to mark a git directory as "safe."  
The conditional to set this env was `git rev-parse --show-toplevel > /dev/null || /iac`.  
When mounting a working dir that is different from /iac and encountering an error with `git rev-parse`, the base dir was incorrectly assigned "/iac." This caused logging git-related information to fail because git would detect "dubious ownership" of a directory not marked "safe."  
The fix is to make the 'or' condition dynamic to the mounted volume path.  

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: [replace this text with permalink URL] 
-->