### PR TITLE
feat: adding learning mode for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ What `easy_infra` does in this case is:
 
 ### Learning mode
 
-The learning mode suppresses the exit codes of any injected validation or security tooling, ensuring the provided commands will run.  This can be configured by
-setting the `LEARNING_MODE` environment variable to `true`, for instance:
+The learning mode suppresses the exit codes of any injected validation, hook, or security tooling, ensuring the provided commands will run.  
+This can be configured by setting the `LEARNING_MODE` environment variable to `true`, for instance:
 
 ```bash
 docker run -e LEARNING_MODE=true -v .:/iac seiso/easy_infra:latest-terraform terraform apply -auto-approve

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -184,13 +184,24 @@ function {{ "scan_" ~ function if scan else function }}() {
         bash "${hook}"
         return=$?
         if [[ "${return:-1}" != 0 ]]; then
-          popd > /dev/null
-          if [[ "${FAIL_FAST:-false}" == "true" ]]; then
-            _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
-            return "${return}"
+          message="${hook} failed to execute properly"
+
+          if [[ "${LEARNING_MODE,,}" != "true" ]]; then
+            # easy_infra denied running the hook because the script failed
+            _log "easy_infra.stdouterr" denied failure "easy_infra" "${dir}" string "${message}"
+            _feedback DEBUGGING "${hook} exited ${return}; learning mode was ${LEARNING_MODE:-null or unset}. Returning ${return}"
+            popd > /dev/null
+            if [[ "${FAIL_FAST:-false}" == "true" ]]; then
+              _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
+              return "${return}"
+            else
+              dir_exit_codes["${dir}"]="${return}"
+              continue
+            fi
           else
-            dir_exit_codes["${dir}"]="${return}"
-            continue
+            # easy_infra allowed the hook due to learning mode, but the script failed
+            _log "easy_infra.stdouterr" allowed failure "easy_infra" "${dir}" string "${message}"
+            _feedback DEBUGGING "${hook} exited ${return}, but suppressing it due to learning mode"
           fi
         fi
       done

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -275,30 +275,24 @@ function {{ "scan_" ~ function if scan else function }}() {
       run_scans="true"
     fi
 
-  {%- if validations is defined %}
+    {%- if validations is defined %}
     ## Validate the input prior to running security tooling
     {%- for validation in validations %}
-    # If the initialization was already run successfully in a non-interactive shell with AUTODETECT not set to true,
-    # don't run it again
-    if [[ -r "/tmp/{{ validation.command | replace(" ", "_") }}_complete" && "${AUTODETECT:-false}" != "true" ]]; then
-      _feedback INFO "Skipping \`{{ validation.command }}\` because it was already run on $(date -d @"$(cat /tmp/{{ validation.command | replace(" ", "_") }}_complete)")"
-    else
-      command {{ validation.command }} &>/tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
-      process_command_exit_status "$?" "{{ validation.command }}" "{{ validation.description }}"
-      return=$?
-      if [[ "${return:-1}" != 0 ]]; then
-        cat /tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
-        if [[ "${LEARNING_MODE,,}" == "true" ]]; then
-          _feedback DEBUGGING "Learning mode enabled, not returning {{ validation.command }}'s exit code of ${return}"
+    command {{ validation.command }} &>/tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
+    process_command_exit_status "$?" "{{ validation.command }}" "{{ validation.description }}"
+    return=$?
+    if [[ "${return:-1}" != 0 ]]; then
+      cat /tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
+      if [[ "${LEARNING_MODE,,}" == "true" ]]; then
+        _feedback DEBUGGING "Learning mode enabled, not returning {{ validation.command }}'s exit code of ${return}"
+      else
+        popd > /dev/null
+        if [[ "${FAIL_FAST:-false}" == "true" ]]; then
+          _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
+          return "${return}"
         else
-          popd > /dev/null
-          if [[ "${FAIL_FAST:-false}" == "true" ]]; then
-            _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
-            return "${return}"
-          else
-            dir_exit_codes["${dir}"]="${return}"
-            continue
-          fi
+          dir_exit_codes["${dir}"]="${return}"
+          continue
         fi
       fi
     fi

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -181,27 +181,24 @@ function {{ "scan_" ~ function if scan else function }}() {
         bash "${hook}"
         return=$?
         if [[ "${return:-1}" != 0 ]]; then
-          if [[ "${LEARNING_MODE,,}" != "true" ]]; then
+          if [[ "${LEARNING_MODE,,}" == "true" ]]; then
+            message="${hook} exited non-zero but learning mode was ${learning_mode} so suppressing the failure"
+            _log "easy_infra.stdouterr" allowed failure "easy_infra" "${dir}" string "${message}"
+            _feedback DEBUGGING "${message}"
+          else
             popd > /dev/null
             if [[ "${FAIL_FAST:-false}" == "true" ]]; then
-              # easy_infra denied running the hook because the script failed
               message="${hook} exited non-zero and fail_fast is set to ${FAIL_FAST}; returning the exit code of ${return}"
               _log "easy_infra.stdouterr" denied failure "easy_infra" "${dir}" string "${message}" 
               _feedback DEBUGGING "${message}"
               return "${return}"
             else
-              # easy_infra captured the non-zero exit code, but did not immediately exit because FAIL_FAST was not true
               message="${hook} exited non-zero and fail_fast is set to ${FAIL_FAST:-null or unset}; capturing the exit code of ${return}"
               _log "easy_infra.stdouterr" denied failure "easy_infra" "${dir}" string "${message}"
               _feedback DEBUGGING "${messsage}"
               dir_exit_codes["${dir}"]="${return}"
               continue
             fi
-          else
-            # easy_infra allowed the hook due to learning mode, but the script failed
-            message="${hook} exited non-zero but learning mode was ${learning_mode} so suppressing the failure"
-            _log "easy_infra.stdouterr" allowed failure "easy_infra" "${dir}" string "${message}"
-            _feedback DEBUGGING "${message}"
           fi
         else
           # Intentionally no _log or _feedback when the return code is 0; we expect those messages are in the hook themselves
@@ -281,22 +278,28 @@ function {{ "scan_" ~ function if scan else function }}() {
   {%- if validations is defined %}
     ## Validate the input prior to running security tooling
     {%- for validation in validations %}
-    command {{ validation.command }} &>/tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
-    process_command_exit_status "$?" "{{ validation.command }}" "{{ validation.description }}"
-    return=$?
-    if [[ "${return:-1}" != 0 ]]; then
-      cat /tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
-      if [[ "${LEARNING_MODE,,}" != "true" ]]; then
-        popd > /dev/null
-        if [[ "${FAIL_FAST:-false}" == "true" ]]; then
-          _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
-          return "${return}"
+    # If the initialization was already run successfully in a non-interactive shell with AUTODETECT not set to true,
+    # don't run it again
+    if [[ -r "/tmp/{{ validation.command | replace(" ", "_") }}_complete" && "${AUTODETECT:-false}" != "true" ]]; then
+      _feedback INFO "Skipping \`{{ validation.command }}\` because it was already run on $(date -d @"$(cat /tmp/{{ validation.command | replace(" ", "_") }}_complete)")"
+    else
+      command {{ validation.command }} &>/tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
+      process_command_exit_status "$?" "{{ validation.command }}" "{{ validation.description }}"
+      return=$?
+      if [[ "${return:-1}" != 0 ]]; then
+        cat /tmp/{{ validation.command | replace(" ", "_") }}_stdouterr
+        if [[ "${LEARNING_MODE,,}" == "true" ]]; then
+          _feedback DEBUGGING "Learning mode enabled, not returning {{ validation.command }}'s exit code of ${return}"
         else
-          dir_exit_codes["${dir}"]="${return}"
-          continue
+          popd > /dev/null
+          if [[ "${FAIL_FAST:-false}" == "true" ]]; then
+            _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
+            return "${return}"
+          else
+            dir_exit_codes["${dir}"]="${return}"
+            continue
+          fi
         fi
-      else
-        _feedback DEBUGGING "Learning mode enabled, not returning {{ validation.command }}'s exit code of ${return}"
       fi
     fi
     {%- endfor -%}
@@ -368,8 +371,10 @@ function {{ "scan_" ~ function if scan else function }}() {
         if [[ "${return:-1}" != 0 ]]; then
           cat /tmp/{{ security_tool | replace("-", "_") }}_stdouterr
 
-          if [[ "${LEARNING_MODE,,}" != "true" ]]; then
-            # easy_infra denied the command because the security tool failed
+          if [[ "${LEARNING_MODE,,}" == "true" ]]; then
+            _log "{{ security_tool }}.stdouterr" allowed failure "${interpolated_security_tool_command}" "${dir}" "${message_type}" "${message_file_path}"
+            _feedback DEBUGGING "{{ security_tool }} running from the ${dir} folder exited ${return}, but suppressing it due to learning mode"
+          else
             _log "{{ security_tool }}.stdouterr" denied failure "${interpolated_security_tool_command}" "${dir}" "${message_type}" "${message_file_path}"
             _feedback DEBUGGING "{{ security_tool }} running from the ${dir} folder exited ${return}; learning mode was ${LEARNING_MODE:-null or unset}. Returning ${return}"
             popd > /dev/null
@@ -380,10 +385,6 @@ function {{ "scan_" ~ function if scan else function }}() {
               dir_exit_codes["${dir}"]="${return}"
               continue
             fi
-          else
-            # easy_infra allowed the command due to learning mode, but the security tool failed
-            _log "{{ security_tool }}.stdouterr" allowed failure "${interpolated_security_tool_command}" "${dir}" "${message_type}" "${message_file_path}"
-            _feedback DEBUGGING "{{ security_tool }} running from the ${dir} folder exited ${return}, but suppressing it due to learning mode"
           fi
         else
           # easy_infra allowed the command and the security tool succeeded

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -275,7 +275,7 @@ function {{ "scan_" ~ function if scan else function }}() {
       run_scans="true"
     fi
 
-    {%- if validations is defined %}
+  {%- if validations is defined %}
     ## Validate the input prior to running security tooling
     {%- for validation in validations %}
     command {{ validation.command }} &>/tmp/{{ validation.command | replace(" ", "_") }}_stdouterr

--- a/build/functions.j2
+++ b/build/functions.j2
@@ -184,25 +184,31 @@ function {{ "scan_" ~ function if scan else function }}() {
         bash "${hook}"
         return=$?
         if [[ "${return:-1}" != 0 ]]; then
-          message="${hook} failed to execute properly"
-
           if [[ "${LEARNING_MODE,,}" != "true" ]]; then
-            # easy_infra denied running the hook because the script failed
-            _log "easy_infra.stdouterr" denied failure "easy_infra" "${dir}" string "${message}"
-            _feedback DEBUGGING "${hook} exited ${return}; learning mode was ${LEARNING_MODE:-null or unset}. Returning ${return}"
             popd > /dev/null
             if [[ "${FAIL_FAST:-false}" == "true" ]]; then
-              _feedback INFO "FAIL_FAST is set to ${FAIL_FAST}; returning the exit code of ${return} immediately"
+              # easy_infra denied running the hook because the script failed
+              message="${hook} exited non-zero and fail_fast is set to ${FAIL_FAST}; returning the exit code of ${return}"
+              _log "easy_infra.stdouterr" denied failure "easy_infra" "${dir}" string "${message}" 
+              _feedback DEBUGGING "${message}"
               return "${return}"
             else
+              # easy_infra captured the non-zero exit code, but did not immediately exit because FAIL_FAST was not true
+              message="${hook} exited non-zero and fail_fast is set to ${FAIL_FAST:-null or unset}; capturing the exit code of ${return}"
+              _log "easy_infra.stdouterr" denied failure "easy_infra" "${dir}" string "${message}"
+              _feedback DEBUGGING "${messsage}"
               dir_exit_codes["${dir}"]="${return}"
               continue
             fi
           else
             # easy_infra allowed the hook due to learning mode, but the script failed
+            message="${hook} exited non-zero but learning mode was ${learning_mode} so suppressing the failure"
             _log "easy_infra.stdouterr" allowed failure "easy_infra" "${dir}" string "${message}"
-            _feedback DEBUGGING "${hook} exited ${return}, but suppressing it due to learning mode"
+            _feedback DEBUGGING "${message}"
           fi
+        else
+          # Intentionally no _log or _feedback when the return code is 0; we expect those messages are in the hook themselves
+          :
         fi
       done
     fi

--- a/docs/Hooks/index.rst
+++ b/docs/Hooks/index.rst
@@ -46,8 +46,7 @@ Configuring Hooks
 -----------------
 
 If you'd like to disable hooks, set the environment variable ``DISABLE_HOOKS`` to ``true``.  
-``LEARNING_MODE`` is also available for hooks. Setting this environment variable to ``true`` will suppress the exit codes of hooks that fail to execute and
-allow easy_infra to complete its tasks.
+``LEARNING_MODE`` also applies to hooks; setting this environment variable to ``true`` suppresses all of the hook's exit codes.
 
 +----------------------+-----------+------------------------------------------------------+
 | Environment variable | Default   | Result                                               |

--- a/docs/Hooks/index.rst
+++ b/docs/Hooks/index.rst
@@ -45,10 +45,14 @@ If you want to overwrite all of the built-in hooks with your own folder of hooks
 Configuring Hooks
 -----------------
 
-If you'd like to disable hooks, set the environment variable ``DISABLE_HOOKS`` to ``true``.
+If you'd like to disable hooks, set the environment variable ``DISABLE_HOOKS`` to ``true``.  
+``LEARNING_MODE`` is also available for hooks. Setting this environment variable to ``true`` will suppress the exit codes of hooks that fail to execute and
+allow easy_infra to complete its tasks.
 
-+----------------------+-----------+----------------------------------------+
-| Environment variable | Default   | Result                                 |
-+======================+===========+========================================+
-| ``DISABLE_HOOKS``    | ``false`` | Disable all hooks when set to ``true`` |
-+----------------------+-----------+----------------------------------------+
++----------------------+-----------+------------------------------------------------------+
+| Environment variable | Default   | Result                                               |
++======================+===========+======================================================+
+| ``DISABLE_HOOKS``    | ``false`` | Disable all hooks when set to ``true``               |
++----------------------+-----------+------------------------------------------------------+
+| ``LEARNING_MODE``    | ``false`` | Suppress failed hook exit codes when set to ``true`` |
++----------------------+-----------+------------------------------------------------------+

--- a/tests/test-hooks/51-intentional-failure.sh
+++ b/tests/test-hooks/51-intentional-failure.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# register_hook: scan_terraform
+
+echo "Error!" 1>&2
+exit 230

--- a/tests/test.py
+++ b/tests/test.py
@@ -1146,7 +1146,6 @@ def run_terraform(*, image: str, user: str) -> None:
         (
             {
                 "DISABLE_HOOKS": "false",
-                "AUTODETECT": "true",
                 "DISABLE_SECURITY": "true",
                 "FAIL_FAST": "true",
                 "LEARNING_MODE": "true",
@@ -1154,6 +1153,27 @@ def run_terraform(*, image: str, user: str) -> None:
             '/bin/bash -c "scan_terraform"',
             0,
         ),  # This tests that the failed script does not fail easy_infra when LM is enabled
+        (
+            {
+                "DISABLE_HOOKS": "false",
+                "DISABLE_SECURITY": "true",
+                "FAIL_FAST": "true",
+                "LEARNING_MODE": "false",
+            },
+            '/bin/bash -c "scan_terraform"',
+            230,
+        ),  # This tests the hook script for a non-zero exit code that would result in easy_infra failing when LM is disabled
+        (
+            {
+                "DISABLE_HOOKS": "false",
+                "DISABLE_SECURITY": "true",
+                "FAIL_FAST": "false",
+                "LEARNING_MODE": "false",
+            },
+            '/bin/bash -c "scan_terraform"',
+            230,
+        ),  # This tests the hook script for a non-zero exit code with FAIL_FAST and LEARNING_MODE both disabled to ensure the
+        # failed hook gets added to the dir_exit_codes array
     ]
 
     LOG.debug("Testing Learning Mode for custom hooks volume mounted at runtime")

--- a/tests/test.py
+++ b/tests/test.py
@@ -1134,9 +1134,31 @@ def run_terraform(*, image: str, user: str) -> None:
             1,
         ),  # This tests DISABLE_HOOKS; it fails because the terraform version used is incorrect
     ]
+
     LOG.debug("Testing the easy_infra hooks against various terraform configurations")
     num_tests_ran += exec_tests(
         tests=tests, volumes=hooks_config_volumes, image=image, user=user
+    )
+
+    # Ensure the easy_infra hooks honor Learning Mode by not failing on hook script errors
+    # Tests is a list of tuples containing the test environment, command, and expected exit code
+    tests: list[tuple[dict, str, int]] = [  # type: ignore
+        (
+            {
+                "DISABLE_HOOKS": "false",
+                "AUTODETECT": "true",
+                "DISABLE_SECURITY": "true",
+                "FAIL_FAST": "true",
+                "LEARNING_MODE": "true",
+            },
+            '/bin/bash -c "scan_terraform"',
+            0,
+        ),  # This tests that the failed script does not fail easy_infra when LM is enabled
+    ]
+
+    LOG.debug("Testing Learning Mode for custom hooks volume mounted at runtime")
+    num_tests_ran += exec_tests(
+        tests=tests, volumes=hooks_script_volumes, image=image, user=user
     )
 
     tests: list[tuple[dict, str, int]] = [  # type: ignore


### PR DESCRIPTION
# Contributor Comments

This change extends the LEARNING_MODE variable to hooks, ensuring failed hooks do not cause easy_infra to fail its task. A test was added that loads a hook with a non-zero exit code to verify this feature.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: [replace this text with permalink URL] 
-->