### PR TITLE
fix: kics report path

### DIFF
--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -51,7 +51,7 @@ packages:
           KICS_INCLUDE_QUERIES: --include-queries
         command: kics scan --type Ansible --no-progress --queries-path ${KICS_INCLUDE_QUERIES_PATH}
           --libraries-path ${KICS_LIBRARY_PATH} --report-formats json --output-path
-          ${KICS_REPORTS} --output-name kics --path .
+          ${KICS_JSON_REPORT_PATH} --output-name kics --path .
         description: directory scan
     version: 2.10.7+merged+base+2.10.8+dfsg-1
     version_argument: --version


### PR DESCRIPTION
# Contributor Comments

This fixes an incorrect variable uses to define the output directory to put KICS scan results in. We are using `KICS_PATH` but it should be `KICS_JSON_REPORT_PATH`.  This seems to be a very long-lived copy/paste mistake, dating back to at least August 2021 via e5803e1cc329395f2a5c72e75401d0258cf14378.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: https://www.wrike.com/open.htm?id=1238772717
-->