### PR TITLE
chore: move to tofuenv for opentofu

### DIFF
--- a/build/Dockerfile.opentofu
+++ b/build/Dockerfile.opentofu
@@ -25,7 +25,7 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && rm -f /usr/local/bin/terratag.tar.gz \
  && chmod 0755 /usr/local/bin/terratag \
  && chown root: /usr/local/bin/terratag \
- && su easy_infra -c "git clone https://github.com/tofuutils/tofuenv.git /home/easy_infra/.tofuenv --depth 1" \
+ && su easy_infra -c "git clone https://github.com/tofuutils/tofuenv.git /home/easy_infra/.tofuenv --depth 1 --branch ${TOFUENV_VERSION}" \
  && rm -rf /home/easy_infra/.tofuenv/.git \
  && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
  && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \

--- a/build/Dockerfile.opentofu
+++ b/build/Dockerfile.opentofu
@@ -7,10 +7,8 @@ ARG OPENTOFU_VERSION
 ENV OPENTOFU_VERSION="${OPENTOFU_VERSION}"
 ARG TERRATAG_VERSION
 ENV TERRATAG_VERSION="${TERRATAG_VERSION}"
-# TODO: Remove ARG default when opentofu support is merged into tfenv
-ARG TFENV_VERSION="add-opentofu-support"
-ENV TFENV_VERSION="${TFENV_VERSION}"
-ENV TFENV_ENGINE="tofu"
+ARG TOFUENV_VERSION
+ENV TOFUENV_VERSION="${TOFUENV_VERSION}"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 COPY --chown=easy_infra:easy_infra .terraformrc /home/easy_infra/
@@ -19,7 +17,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 # hadolint ignore=DL3008
 RUN apt-get update \
- # unzip is required for tfenv now and at runtime
+ # unzip is required for tofuenv now and at runtime
  && apt-get install -y --no-install-recommends unzip \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/debconf/*-old
 RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSION}/terratag_${TERRATAG_VERSION#v}_linux_${BUILDARCH}.tar.gz -o /usr/local/bin/terratag.tar.gz \
@@ -27,15 +25,14 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && rm -f /usr/local/bin/terratag.tar.gz \
  && chmod 0755 /usr/local/bin/terratag \
  && chown root: /usr/local/bin/terratag \
- # TODO: Replace opentofu with tfenv this after it gets merged into tfenv
- && su easy_infra -c "git clone https://github.com/opentofu/tfenv.git /home/easy_infra/.tfenv --depth 1 --branch ${TFENV_VERSION}" \
- && rm -rf /home/easy_infra/.tfenv/.git \
+ && su easy_infra -c "git clone https://github.com/tofuutils/tofuenv.git /home/easy_infra/.tofuenv --depth 1" \
+ && rm -rf /home/easy_infra/.tofuenv/.git \
  && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
  && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \
- && ln -s /home/easy_infra/.tfenv/bin/* /home/easy_infra/.local/bin \
- && su - easy_infra -c "TFENV_ENGINE=${TFENV_ENGINE} tfenv install ${OPENTOFU_VERSION}" \
- && su - easy_infra -c "TFENV_ENGINE=${TFENV_ENGINE} tfenv use ${OPENTOFU_VERSION}" \
+ && ln -s /home/easy_infra/.tofuenv/bin/* /home/easy_infra/.local/bin \
+ && su - easy_infra -c "tofuenv install ${OPENTOFU_VERSION}" \
+ && su - easy_infra -c "tofuenv use ${OPENTOFU_VERSION}" \
  && command tofu -install-autocomplete \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/debconf/*-old
 USER easy_infra

--- a/build/Dockerfile.terraform
+++ b/build/Dockerfile.terraform
@@ -9,7 +9,6 @@ ARG TERRATAG_VERSION
 ENV TERRATAG_VERSION="${TERRATAG_VERSION}"
 ARG TFENV_VERSION
 ENV TFENV_VERSION="${TFENV_VERSION}"
-ENV TFENV_ENGINE="terraform"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 COPY --chown=easy_infra:easy_infra .terraformrc /home/easy_infra/
@@ -26,15 +25,14 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && rm -f /usr/local/bin/terratag.tar.gz \
  && chmod 0755 /usr/local/bin/terratag \
  && chown root: /usr/local/bin/terratag \
- # TODO: Replace opentofu with tfenv this after it gets merged into tfenv
- && su easy_infra -c "git clone https://github.com/opentofu/tfenv.git /home/easy_infra/.tfenv --depth 1 --branch ${TFENV_VERSION}" \
+ && su easy_infra -c "git clone https://github.com/tfutils/tfenv.git /home/easy_infra/.tfenv --depth 1 --branch ${TFENV_VERSION}" \
  && rm -rf /home/easy_infra/.tfenv/.git \
  && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
  && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \
  && ln -s /home/easy_infra/.tfenv/bin/* /home/easy_infra/.local/bin \
- && su - easy_infra -c "TFENV_ENGINE=${TFENV_ENGINE} tfenv install ${TERRAFORM_VERSION}" \
- && su - easy_infra -c "TFENV_ENGINE=${TFENV_ENGINE} tfenv use ${TERRAFORM_VERSION}" \
+ && su - easy_infra -c "tfenv install ${TERRAFORM_VERSION}" \
+ && su - easy_infra -c "tfenv use ${TERRAFORM_VERSION}" \
  && command terraform -install-autocomplete \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/debconf/*-old
 USER easy_infra

--- a/build/Dockerfrag.opentofu
+++ b/build/Dockerfrag.opentofu
@@ -2,15 +2,13 @@ ARG OPENTOFU_VERSION
 ENV OPENTOFU_VERSION="${OPENTOFU_VERSION}"
 ARG TERRATAG_VERSION
 ENV TERRATAG_VERSION="${TERRATAG_VERSION}"
-# TODO: Remove ARG default when opentofu support is merged into tfenv
-ARG TFENV_VERSION="add-opentofu-support"
-ENV TFENV_VERSION="${TFENV_VERSION}"
-ENV TFENV_ENGINE="tofu"
+ARG TOFUENV_VERSION
+ENV TOFUENV_VERSION="${TOFUENV_VERSION}"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.terraform.d /home/easy_infra/.terraform.d
 COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.terraformrc /home/easy_infra/.terraformrc
-COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.tfenv /home/easy_infra/.tfenv
+COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.tofuenv /home/easy_infra/.tofuenv
 COPY --from=opentofu --chown=easy_infra:easy_infra /usr/local/bin /usr/local/bin
 COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.local /home/easy_infra/.local
 

--- a/build/Dockerfrag.terraform
+++ b/build/Dockerfrag.terraform
@@ -4,7 +4,6 @@ ARG TERRATAG_VERSION
 ENV TERRATAG_VERSION="${TERRATAG_VERSION}"
 ARG TFENV_VERSION
 ENV TFENV_VERSION="${TFENV_VERSION}"
-ENV TFENV_ENGINE="terraform"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 COPY --from=terraform --chown=easy_infra:easy_infra /home/easy_infra/.terraform.d /home/easy_infra/.terraform.d

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -62,6 +62,13 @@ if [ "$#" -eq 0 ]; then
     else
       echo -e "terraform\t ${TERRAFORM_VERSION}"
     fi
+  elif [ -x "$(which tofu)" ]; then
+    current_version=$(cat /home/easy_infra/.tofuenv/version)
+    if [[ "${OPENTOFU_VERSION}" != "${current_version}" ]]; then
+      echo -e "tofu\t ${OPENTOFU_VERSION} (customized)"
+    else
+      echo -e "tofu\t ${OPENTOFU_VERSION}"
+    fi
   fi
 
   exec bash

--- a/build/hooks/40-set_default_opentofu_version.sh
+++ b/build/hooks/40-set_default_opentofu_version.sh
@@ -6,7 +6,7 @@
 source /usr/local/bin/common.sh
 
 
-current_version=$(cat /home/easy_infra/.tfenv/version)
+current_version=$(cat /home/easy_infra/.tofuenv/version)
 output_log="/var/log/$(basename "${BASH_SOURCE[0]%%.sh}.log")"
 
 if [[ -z "${OPENTOFU_VERSION}" ]]; then
@@ -18,7 +18,7 @@ elif [[ "${OPENTOFU_VERSION}" == "${current_version}" ]]; then
 fi
 
 # OPENTOFU_VERSION is not the installed and active version; make it so
-tfenv install "${OPENTOFU_VERSION}" &>>"${output_log}"
+tofuenv install "${OPENTOFU_VERSION}" &>>"${output_log}"
 return=$?
 if [[ "${return}" != 0 ]]; then
   message="Unable to install OpenTofu ${OPENTOFU_VERSION}, continuing to use version ${current_version}..."
@@ -30,5 +30,5 @@ if [[ "${return}" != 0 ]]; then
 fi
 
 _feedback INFO "Switching OpenTofu version to ${OPENTOFU_VERSION} due to the provided OPENTOFU_VERSION environment variable..." | tee -a "${output_log}"
-tfenv use "${OPENTOFU_VERSION}" &>>"${output_log}"
+tofuenv use "${OPENTOFU_VERSION}" &>>"${output_log}"
 exit $?

--- a/build/hooks/50-opentofu_dynamic_version_use.sh
+++ b/build/hooks/50-opentofu_dynamic_version_use.sh
@@ -13,17 +13,17 @@ if [[ "${AUTODETECT}" != "true" ]]; then
   exit 0
 fi
 
-current_version=$(cat /home/easy_infra/.tfenv/version)
+current_version=$(cat /home/easy_infra/.tofuenv/version)
 
-# Use tfenv to get the minimum version of opentofu specified in the opentofu code (in the current directory)
-opentofu_min_required="$(tfenv min-required 2>>"${output_log}")"
+# Use tofuenv to get the minimum version of opentofu specified in the opentofu code (in the current directory)
+opentofu_min_required="$(tofuenv min-required 2>>"${output_log}")"
 
 if [[ ! "${opentofu_min_required}" ]]; then
   message="Unable to detect the minimum required version of OpenTofu, falling back to version ${OPENTOFU_VERSION}"
   _feedback WARNING "${message}" | tee -a "${output_log}"
   # shellcheck disable=SC2154 # dir is exported in the parent process, see functions.j2
   _log "easy_infra.hook" info failure "${fully_qualified_script}" "${dir}" string "${message}"
-  tfenv use "${OPENTOFU_VERSION}" &>>"${output_log}"
+  tofuenv use "${OPENTOFU_VERSION}" &>>"${output_log}"
   exit $?
 fi
 
@@ -35,22 +35,22 @@ fi
 ## Check if the detected required version of opentofu is already installed, and if so, use it
 if [[ "${OPENTOFU_VERSION}" == "${opentofu_min_required}" ]]; then
   _feedback INFO "The detected minimum OpenTofu version of ${opentofu_min_required} is already installed; ensuring it's in use..." | tee -a "${output_log}"
-  tfenv use "${OPENTOFU_VERSION}" &>>"${output_log}"
+  tofuenv use "${OPENTOFU_VERSION}" &>>"${output_log}"
   exit $?
 fi
 
 ## Change versions to the detected min_required
-tfenv install "${opentofu_min_required}" &>/dev/null
+tofuenv install "${opentofu_min_required}" &>/dev/null
 return=$?
 if [[ "${return}" != 0 ]]; then
   message="Unable to install OpenTofu ${opentofu_min_required}, falling back to version ${OPENTOFU_VERSION}..."
   _feedback WARNING "${message}" | tee -a "${output_log}"
   # shellcheck disable=SC2154 # dir is exported in the parent process, see functions.j2
   _log "easy_infra.hook" info failure "${fully_qualified_script}" "${dir}" string "${message}"
-  tfenv use "${OPENTOFU_VERSION}" &>/dev/null
+  tofuenv use "${OPENTOFU_VERSION}" &>/dev/null
   exit $?
 fi
 
 _feedback INFO "Switching OpenTofu version to ${opentofu_min_required}..." | tee -a "${output_log}"
-tfenv use "${opentofu_min_required}" &>>"${output_log}"
+tofuenv use "${opentofu_min_required}" &>>"${output_log}"
 exit $?

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -127,14 +127,25 @@ packages:
     allow_filter:
     - match: exec
       position: 0
-    allow_update: false
     file_extensions: *id003
     helper:
     - terraform
+    monitor:
+      env_vars:
+      - TF_DATA_DIR
+    security: *id004
+    version: v3.0.0
+    version_argument: --version
+  tofuenv:
+    allow_filter:
+    - match: exec
+      position: 0
+    file_extensions: *id003
+    helper:
     - opentofu
     monitor:
       env_vars:
       - TF_DATA_DIR
     security: *id004
-    version: add-opentofu-support
+    version: v1.0.3
     version_argument: --version

--- a/easy_infra/constants.py
+++ b/easy_infra/constants.py
@@ -66,6 +66,7 @@ GITHUB_REPOS_RELEASES = {
     "hashicorp/consul-template",
     "hashicorp/envconsul",
     "tfutils/tfenv",
+    "tofuutils/tofuenv",
 }
 GITHUB_REPOS_TAGS = {"aws/aws-cli"}
 PYTHON_PACKAGES = {"checkov"}

--- a/tests/test.py
+++ b/tests/test.py
@@ -728,6 +728,7 @@ def run_unified_terraform_opentofu(
 ) -> None:
     """Run the unified terraform and opentofu tests"""
     key = base_command if base_command == "terraform" else "opentofu"
+    package_manager = "tfenv" if base_command == "terraform" else "tofuenv"
     num_tests_ran: int = 0
     working_dir: str = "/iac/"
     environment: dict[str, str] = {"TF_DATA_DIR": "/tmp"}
@@ -1018,7 +1019,7 @@ def run_unified_terraform_opentofu(
     # Tests is a list of tuples containing the test environment, command, and expected exit code
     tests: list[tuple[dict, str, int]] = [  # type: ignore
         ({}, f"{base_command} init", 0),
-        ({}, "tfenv exec init", 0),
+        ({}, f"{package_manager} exec init", 0),
         (
             {},
             f'/usr/bin/env bash -c "{base_command} init && false"',
@@ -1026,7 +1027,7 @@ def run_unified_terraform_opentofu(
         ),
         (
             {},
-            '/usr/bin/env bash -c "tfenv exec init && false"',
+            f'/usr/bin/env bash -c "{package_manager} exec init && false"',
             1,
         ),
     ]
@@ -1040,9 +1041,9 @@ def run_unified_terraform_opentofu(
     # Tests is a list of tuples containing the test environment, command, and expected exit code
     tests: list[tuple[dict, str, int]] = [  # type: ignore
         ({}, f"{base_command} init", 0),
-        ({}, "tfenv exec init", 0),
+        ({}, f"{package_manager} exec init", 0),
         ({}, f"scan_{base_command}", 0),
-        ({}, "scan_tfenv", 0),
+        ({}, f"scan_{package_manager}", 0),
         (
             {},
             f'/bin/bash -c "{base_command} init && {base_command} validate && echo no | {base_command} apply"',
@@ -1080,7 +1081,7 @@ def run_unified_terraform_opentofu(
     # Tests is a list of tuples containing the test environment, command, and expected exit code
     tests: list[tuple[dict, str, int]] = [  # type: ignore
         ({"DISABLE_SECURITY": "true"}, f"{base_command} init", 0),
-        ({"DISABLE_SECURITY": "true"}, "tfenv exec init", 0),
+        ({"DISABLE_SECURITY": "true"}, f"{package_manager} exec init", 0),
         ({"DISABLE_SECURITY": "true"}, f"scan_{base_command}", 0),
         ({}, f'/usr/bin/env bash -c "DISABLE_SECURITY=true {base_command} init"', 0),
         (
@@ -1128,7 +1129,7 @@ def run_unified_terraform_opentofu(
     # Tests is a list of tuples containing the test environment, command, and expected exit code
     tests: list[tuple[dict, str, int]] = [  # type: ignore
         ({}, f"{base_command} init", 1),
-        ({}, "tfenv exec plan", 1),
+        ({}, f"{package_manager} exec plan", 1),
         ({}, f"scan_{base_command}", 1),
         (
             {},


### PR DESCRIPTION
# Contributor Comments

Since tfenv will not support opentofu per https://github.com/tfutils/tfenv/pull/411, we need to move to use [tofuenv](https://github.com/tofuutils/tofuenv), a tfenv fork with opentofu support.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: [replace this text with permalink URL] 
-->