### PR TITLE
fix: update rtd yaml to fix build error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
# Contributor Comments

This PR fixes an error experienced when publishing document changes to ReadTheDocs, adding the 'build' section to the yaml file. 

<img width="450" alt="Screenshot 2024-01-10 at 9 21 00 AM" src="https://github.com/SeisoLLC/easy_infra/assets/119868939/d0b5e414-d1e0-4c72-85a9-15278024ce58">

Reference:
https://github.com/readthedocs/readthedocs.org/issues/8912#issuecomment-1037868701
https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: [replace this text with permalink URL] 
-->