### PR TITLE
feat: distribute multiplatform images

### DIFF
--- a/build/Dockerfile.ansible
+++ b/build/Dockerfile.ansible
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS ansible
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS ansible
 
 ARG ANSIBLE_VERSION
 ENV ANSIBLE_VERSION="${ANSIBLE_VERSION}"

--- a/build/Dockerfile.ansible-aws
+++ b/build/Dockerfile.ansible-aws
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG_TOOL_ONLY
 
-FROM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-aws
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-aws
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ansible-galaxy collection install amazon.aws

--- a/build/Dockerfile.ansible-azure
+++ b/build/Dockerfile.ansible-azure
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG_TOOL_ONLY
 
-FROM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-azure
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-azure
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN ansible-galaxy collection install azure.azcollection

--- a/build/Dockerfile.aws-cli
+++ b/build/Dockerfile.aws-cli
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS aws-cli
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS aws-cli
 
 ARG AWS_CLI_ARCH
 ARG AWS_CLI_VERSION

--- a/build/Dockerfile.azure-cli
+++ b/build/Dockerfile.azure-cli
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS azure-cli
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS azure-cli
 
 ARG AZURE_CLI_VERSION
 ENV AZURE_CLI_VERSION="${AZURE_CLI_VERSION}"

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -7,8 +7,10 @@ ARG EASY_INFRA_TAG
 # https://docs.docker.com/engine/reference/builder/#scope
 ARG EASY_INFRA_TAG_TOOL_ONLY
 
+# TARGETPLATFORM is special cased by docker and doesn't need the initial ARG
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # The dockerfile base must start with FROM ... AS base
-FROM "${FROM_IMAGE}":"${FROM_IMAGE_TAG}" AS base
+FROM --platform=$TARGETPLATFORM "${FROM_IMAGE}":"${FROM_IMAGE_TAG}" AS base
 
 ARG BUILDARCH
 ARG TRACE="false"

--- a/build/Dockerfile.checkov
+++ b/build/Dockerfile.checkov
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS checkov
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS checkov
 
 ARG CHECKOV_VERSION
 ENV CHECKOV_VERSION="${CHECKOV_VERSION}"

--- a/build/Dockerfile.j2
+++ b/build/Dockerfile.j2
@@ -25,7 +25,8 @@ ARG {{ argument }}
 {{ dockerfile }}
 {% endfor %}
 
-FROM base as final
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM base as final
 
 USER easy_infra
 

--- a/build/Dockerfile.kics
+++ b/build/Dockerfile.kics
@@ -1,6 +1,7 @@
 ARG KICS_VERSION
 
-FROM checkmarx/kics:"${KICS_VERSION}-debian" AS kics
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM checkmarx/kics:"${KICS_VERSION}-debian" AS kics
 
 ARG KICS_VERSION
 ENV KICS_VERSION="${KICS_VERSION}"

--- a/build/Dockerfile.opentofu
+++ b/build/Dockerfile.opentofu
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS opentofu
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS opentofu
 
 ARG BUILDARCH
 ARG OPENTOFU_VERSION

--- a/build/Dockerfile.terraform
+++ b/build/Dockerfile.terraform
@@ -1,6 +1,7 @@
 ARG EASY_INFRA_TAG
 
-FROM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS terraform
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM seiso/easy_infra_base:"${EASY_INFRA_TAG}" AS terraform
 
 ARG BUILDARCH
 ARG TERRAFORM_VERSION


### PR DESCRIPTION
# Contributor Comments

This is a WIP because it was on my mind today and I wanted to stash some reminders for others / future me in case someone takes on this work. Anyone with write access to the repo is welcome to take this over and push commits to the branch, etc. to get this done.

The biggest difficulty with this work is that `docker-py` doesn't yet support `BUILDKIT` per https://github.com/docker/docker-py/issues/2230

There are a couple of options:
1. We could create and distribute amd- and arm-specific tags (i.e. `seiso/easy_infra:latest-opentofu-aws-arm64`, `seiso/easy_infra:latest-opentofu-aws-amd64`, etc. 🤮). This would be a workaround, but pretty easy to do as it doesn't require `BULDKIT`, is already baseline supported (i.e. if you `task build` on an arm64 system today, the image that's created is for arm64 as of dbd3a8bf19f607b0d930bfaa1d9a7ae51e7cf794), and can be done with GitHub-hosted runners as of https://github.com/actions/runner-images/issues/5631. We'd need to update [this matrix](https://github.com/SeisoLLC/easy_infra/blob/3e4d5397be839ac2e9d9c53b9818f77e732d3ca1/.github/workflows/commit.yml#L174) to additionally include `ubuntu-24.04-arm64` and then update `runs-on:` in line with [this documentation](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-using-a-multi-dimension-matrix). I've already pre-created the `ubuntu-24.04-arm64` runner in our org it requires authorization of an additional actions spend [here](https://github.com/organizations/SeisoLLC/settings/billing/summary) in order to use it (it doesn't use our monthly pre-allocated 3,000 minutes).
2. Wait for `BUILDKIT` and implement something along the lines of [the goat's reusable Taskfile.yml](https://github.com/SeisoLLC/goat/blob/af90e38b11c1846bfb84fe1f0772e4ebe60ea96b/Task/Taskfile.yml#L135-L191) and [the Dockerfile that cookiecutter-python creates](https://github.com/SeisoLLC/cookiecutter-python/blob/96cf74f157e2d5fa59042e67f790c245e7cfc3ab/%7B%7Bcookiecutter.project_name%7Creplace(%22%20%22%2C%20%22%22)%7D%7D/Dockerfile#L3-L5) (the latter of which I've already implemented in this branch). It would require tweaks to our [`build_and_tag`](https://github.com/SeisoLLC/easy_infra/blob/3e4d5397be839ac2e9d9c53b9818f77e732d3ca1/easy_infra/utils.py#L724) function.
3. We move all the building and tagging logic to run scripts (especially `docker buildx build`) on the builder's host. I would recommend making a `scripts/` dir, creating some helper python scripts in there, and then calling that from `Taskfile.yml` if this is the chosen approach, otherwise the `Taskfile.yml` will be massive/too complex.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch.
- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines [here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).