### PR TITLE
fix: allow tofu/terraform caches to stay local

### DIFF
--- a/build/.terraformrc
+++ b/build/.terraformrc
@@ -1,2 +1,0 @@
-plugin_cache_dir   = "$HOME/.terraform.d/plugin-cache"
-

--- a/build/Dockerfile.opentofu
+++ b/build/Dockerfile.opentofu
@@ -11,8 +11,6 @@ ARG TOFUENV_VERSION
 ENV TOFUENV_VERSION="${TOFUENV_VERSION}"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-COPY --chown=easy_infra:easy_infra .terraformrc /home/easy_infra/
-
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 # hadolint ignore=DL3008
@@ -27,8 +25,6 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && chown root: /usr/local/bin/terratag \
  && su easy_infra -c "git clone https://github.com/tofuutils/tofuenv.git /home/easy_infra/.tofuenv --depth 1 --branch ${TOFUENV_VERSION}" \
  && rm -rf /home/easy_infra/.tofuenv/.git \
- && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
- && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \
  && ln -s /home/easy_infra/.tofuenv/bin/* /home/easy_infra/.local/bin \
  && su - easy_infra -c "tofuenv install ${OPENTOFU_VERSION}" \

--- a/build/Dockerfile.opentofu
+++ b/build/Dockerfile.opentofu
@@ -25,6 +25,8 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && chown root: /usr/local/bin/terratag \
  && su easy_infra -c "git clone https://github.com/tofuutils/tofuenv.git /home/easy_infra/.tofuenv --depth 1 --branch ${TOFUENV_VERSION}" \
  && rm -rf /home/easy_infra/.tofuenv/.git \
+ && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
+ && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \
  && ln -s /home/easy_infra/.tofuenv/bin/* /home/easy_infra/.local/bin \
  && su - easy_infra -c "tofuenv install ${OPENTOFU_VERSION}" \

--- a/build/Dockerfile.terraform
+++ b/build/Dockerfile.terraform
@@ -25,6 +25,9 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && chown root: /usr/local/bin/terratag \
  && su easy_infra -c "git clone https://github.com/tfutils/tfenv.git /home/easy_infra/.tfenv --depth 1 --branch ${TFENV_VERSION}" \
  && rm -rf /home/easy_infra/.tfenv/.git \
+
+ && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
+ && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \
  && ln -s /home/easy_infra/.tfenv/bin/* /home/easy_infra/.local/bin \
  && su - easy_infra -c "tfenv install ${TERRAFORM_VERSION}" \

--- a/build/Dockerfile.terraform
+++ b/build/Dockerfile.terraform
@@ -25,7 +25,6 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && chown root: /usr/local/bin/terratag \
  && su easy_infra -c "git clone https://github.com/tfutils/tfenv.git /home/easy_infra/.tfenv --depth 1 --branch ${TFENV_VERSION}" \
  && rm -rf /home/easy_infra/.tfenv/.git \
-
  && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
  && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \

--- a/build/Dockerfile.terraform
+++ b/build/Dockerfile.terraform
@@ -11,8 +11,6 @@ ARG TFENV_VERSION
 ENV TFENV_VERSION="${TFENV_VERSION}"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-COPY --chown=easy_infra:easy_infra .terraformrc /home/easy_infra/
-
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 # hadolint ignore=DL3008
@@ -27,8 +25,6 @@ RUN curl -L https://github.com/env0/terratag/releases/download/${TERRATAG_VERSIO
  && chown root: /usr/local/bin/terratag \
  && su easy_infra -c "git clone https://github.com/tfutils/tfenv.git /home/easy_infra/.tfenv --depth 1 --branch ${TFENV_VERSION}" \
  && rm -rf /home/easy_infra/.tfenv/.git \
- && su easy_infra -c "mkdir -p /home/easy_infra/.terraform.d/plugin-cache" \
- && mkdir -p /home/easy_infra/.terraform.d/plugin-cache \
  && mkdir -p /home/easy_infra/.local/bin/ \
  && ln -s /home/easy_infra/.tfenv/bin/* /home/easy_infra/.local/bin \
  && su - easy_infra -c "tfenv install ${TERRAFORM_VERSION}" \

--- a/build/Dockerfrag.kics
+++ b/build/Dockerfrag.kics
@@ -10,7 +10,3 @@ COPY --from=kics --chown=easy_infra:easy_infra /app/bin/kics /usr/local/bin/kics
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/assets/libraries /home/easy_infra/.kics/assets/libraries
 COPY --from=kics --chown=easy_infra:easy_infra /app/bin/assets/queries /home/easy_infra/.kics/assets/queries
 COPY --from=kics --chown=easy_infra:easy_infra /tmp/reports/kics /tmp/reports/kics
-
-# Intentionally left out because KICS is not currently used in the Terraform image
-#COPY --from=kics --chown=easy_infra:easy_infra /root/.terraform.d/plugins/linux_amd64 /home/easy_infra/.terraform.d/plugins/linux_amd64
-#COPY --from=kics --chown=easy_infra:easy_infra /usr/bin/terraformer /usr/local/bin/terraformer

--- a/build/Dockerfrag.opentofu
+++ b/build/Dockerfrag.opentofu
@@ -7,7 +7,6 @@ ENV TOFUENV_VERSION="${TOFUENV_VERSION}"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.terraform.d /home/easy_infra/.terraform.d
-COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.terraformrc /home/easy_infra/.terraformrc
 COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.tofuenv /home/easy_infra/.tofuenv
 COPY --from=opentofu --chown=easy_infra:easy_infra /usr/local/bin /usr/local/bin
 COPY --from=opentofu --chown=easy_infra:easy_infra /home/easy_infra/.local /home/easy_infra/.local

--- a/build/Dockerfrag.terraform
+++ b/build/Dockerfrag.terraform
@@ -7,7 +7,6 @@ ENV TFENV_VERSION="${TFENV_VERSION}"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 COPY --from=terraform --chown=easy_infra:easy_infra /home/easy_infra/.terraform.d /home/easy_infra/.terraform.d
-COPY --from=terraform --chown=easy_infra:easy_infra /home/easy_infra/.terraformrc /home/easy_infra/.terraformrc
 COPY --from=terraform --chown=easy_infra:easy_infra /home/easy_infra/.tfenv /home/easy_infra/.tfenv
 COPY --from=terraform --chown=easy_infra:easy_infra /usr/local/bin /usr/local/bin
 COPY --from=terraform --chown=easy_infra:easy_infra /home/easy_infra/.local /home/easy_infra/.local

--- a/docs/Terraform/index.rst
+++ b/docs/Terraform/index.rst
@@ -10,7 +10,7 @@ environments as Infrastructure as Code (IaC).
 ``easy_infra`` uses security tools, such as `Checkov <https://www.checkov.io/>`_, to transparently assess the provided IaC against the defined security policy.
 
 .. warning::
-    ``easy_infra``'s `terraform` images are incompatable with the terraform ``-chdir`` argument as documented `here
+    ``easy_infra``'s `terraform` images are incompatible with the terraform ``-chdir`` argument as documented `here
     <https://developer.hashicorp.com/terraform/cli/commands#switching-working-directory-with-chdir>`_.
 
 
@@ -20,11 +20,11 @@ Use Cases
 If you use Software Version Control (such as ``git``) to manage your Terraform IaC, consider executing ``terraform validate`` with easy_infra as a
 pipeline action on commit or pull request::
 
-    docker run -v .:/iac seiso/easy_infra:latest-terraform terraform validate
+    docker run -v "$(pwd)":/iac seiso/easy_infra:latest-terraform terraform validate
 
 You can also use easy_infra to deploy your infrastructure using ``terraform plan`` and ``terraform deploy``::
 
-    docker run -v .:/iac seiso/easy_infra:latest-terraform /bin/bash -c "terraform plan && terraform apply -auto-approve"
+    docker run -v "$(pwd)":/iac seiso/easy_infra:latest-terraform /bin/bash -c "terraform plan && terraform apply -auto-approve"
 
 
 Customizing Checkov
@@ -91,7 +91,7 @@ For instance::
     CHECKOV_BASELINE=/iac/.checkov.baseline
     CHECKOV_EXTERNAL_CHECKS_DIR=/iac/checkov_rules/
     CHECKOV_SKIP_CHECK=CKV_AWS_20
-    docker run --env-file <(env | grep ^CHECKOV_) -v .:/iac easy_infra:latest-terraform terraform validate
+    docker run --env-file <(env | grep ^CHECKOV_) -v "$(pwd)":/iac easy_infra:latest-terraform terraform validate
 
 In addition, you can customize some ``checkov``-specific environment variables at runtime for different effects. By setting these environment variables, you are
 customizing the ``checkov`` environment **only** while it is running.
@@ -105,16 +105,16 @@ customizing the ``checkov`` environment **only** while it is running.
 For instance, the following command will run with ``checkov`` in debug mode (which is separate from running ``easy_infra`` in debug mode)::
 
     CHECKOV_LOG_LEVEL=DEBUG
-    docker run --env CHECKOV_LOG_LEVEL -v .:/iac easy_infra:latest-terraform terraform validate
+    docker run --env CHECKOV_LOG_LEVEL -v "$(pwd)":/iac easy_infra:latest-terraform terraform validate
 
 
-Preinstalled Hooks
+Pre-installed Hooks
 ^^^^^^^^^^^^^^^^^^
 
-There are some preinstalled hooks in ``/opt/hooks/bin/`` which apply to terraform commands:
+There are some pre-installed hooks in ``/opt/hooks/bin/`` which apply to terraform commands:
 
 * If the ``TERRAFORM_VERSION`` environment variable is customized, easy_infra will attempt to install and switch to that version at runtime. This
-  effectively makes it the "new default" in place of the version which was preinstalled in the version of the easy_infra container.
+  effectively makes it the "new default" in place of the version which was pre-installed in the version of the easy_infra container.
 * If ``AUTODETECT`` is set to ``true``, easy_infra will attempt to detect and install the correct version of terraform for each folder that a
   ``terraform`` command runs in using the ``required_version`` block in the code. Since this is module-specific, it will override the default
   terraform version to use (specified by ``TERRAFORM_VERSION``; see the prior bullet).
@@ -123,9 +123,9 @@ There are some preinstalled hooks in ``/opt/hooks/bin/`` which apply to terrafor
 Terraform Caching
 ^^^^^^^^^^^^^^^^^
 
-If you're working with the same terraform code across multiple runs, you can leverage the cache::
+If you're working with the same terraform code across multiple runs, you can leverage the cache which is automatically placed in the current working directory::
 
-    docker run -v .:/iac -v "$(pwd)/plugin-cache:/home/easy_infra/.terraform.d/plugin-cache" easy_infra:latest-terraform /bin/bash -c "terraform init; terraform validate"
+    docker run -v "$(pwd)":/iac easy_infra:latest-terraform /bin/bash -c "terraform init; terraform validate"
 
 
 Disabling Security


### PR DESCRIPTION
# Contributor Comments

This removes the `.terraformrc` and updates the related documentation. By pre-configuring a plugin cache in our images, we make it so that `init`s result in `.terraform/providers/...` directories which symlink to `/home/easy_infra/.terraform.d/plugin-cache/...` which not be what's intended by our users.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch.
- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines [here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).