### PR TITLE
fix: updating base image and dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -27,11 +27,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:5cfc40ae9f68311075d27ef68a4841bdc5cc7f6cf86671b49f00607d30188e2d",
-                "sha256:a9d1c946ada25098d790e079ba2a1b112157278f3fb7e718ae6a9252f5835dc8"
+                "sha256:6aaea045f938c735ead292204afdb977a36e989522b7833ef6fea94de743f442",
+                "sha256:db676dc4f3ae6bfe31cda227dc60e03438378d7a896aec57422c95634e8d722f"
             ],
             "markers": "python_full_version >= '3.9.0'",
-            "version": "==3.3.5"
+            "version": "==3.3.6"
         },
         "babel": {
             "hashes": [
@@ -59,11 +59,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
-                "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"
+                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.8.30"
+            "version": "==2024.12.14"
         },
         "cfgv": {
             "hashes": [
@@ -243,11 +243,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:c097384259f49e372f4ea00a19719d95ae27dd5ff0fd77ad630aa891306b82f3",
-                "sha256:fab5c716c24d7a789775228823797296a2994b075fb6080ac83a102772a98cbd"
+                "sha256:62f5dae9b5fef52c84cc188514e9ea4f3f636b1d8799ab5ebc475471f9e47a02",
+                "sha256:9edba65473324c2ea9684b1f944fe3191db3345e50b6d04571d10ed164f8d7bd"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.6.2"
+            "version": "==2.6.3"
         },
         "idna": {
             "hashes": [
@@ -425,12 +425,12 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:2f846a466dd023513240bc140ad2dd73bfc080a5d85a710afdb728c420a5a2b9",
-                "sha256:9f3dcc87b1203e612b78d91a896407787e708b3f189b5fa0b307712d49ff0c6e"
+                "sha256:77f068c287d49b8683cd7c6e624243c74f92890f767f106ffa1ddf3c0a54cb7a",
+                "sha256:9ec054ec992cd05ad30a6df1676229739a73f8feeabf3912c995d17601052b01"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.9.0'",
-            "version": "==3.3.1"
+            "version": "==3.3.2"
         },
         "pyyaml": {
             "hashes": [
@@ -591,11 +591,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba",
-                "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4"
+                "sha256:23eae1b4516ecd610481eda647f3a7c09aea295055337331bb4e6892ecce47b0",
+                "sha256:2c9c3262bb8e7b87ea801d715fae4495e6032450c71d2309be9550e7364049aa"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==20.27.1"
+            "version": "==20.28.0"
         }
     }
 }

--- a/build/Dockerfile.ansible-aws
+++ b/build/Dockerfile.ansible-aws
@@ -3,4 +3,4 @@ ARG EASY_INFRA_TAG_TOOL_ONLY
 FROM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-aws
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN ansible-galaxy collection install amazon.aws --upgrade
+RUN ansible-galaxy collection install amazon.aws --force

--- a/build/Dockerfile.ansible-aws
+++ b/build/Dockerfile.ansible-aws
@@ -3,4 +3,4 @@ ARG EASY_INFRA_TAG_TOOL_ONLY
 FROM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-aws
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN ansible-galaxy collection install amazon.aws
+RUN ansible-galaxy collection install amazon.aws --upgrade

--- a/build/Dockerfile.ansible-azure
+++ b/build/Dockerfile.ansible-azure
@@ -3,4 +3,4 @@ ARG EASY_INFRA_TAG_TOOL_ONLY
 FROM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-azure
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN ansible-galaxy collection install azure.azcollection
+RUN ansible-galaxy collection install azure.azcollection --upgrade

--- a/build/Dockerfile.ansible-azure
+++ b/build/Dockerfile.ansible-azure
@@ -3,4 +3,4 @@ ARG EASY_INFRA_TAG_TOOL_ONLY
 FROM seiso/easy_infra:"${EASY_INFRA_TAG_TOOL_ONLY}" AS ansible-azure
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN ansible-galaxy collection install azure.azcollection --upgrade
+RUN ansible-galaxy collection install azure.azcollection --force

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG FROM_IMAGE=ubuntu
-ARG FROM_IMAGE_TAG=23.10
+ARG FROM_IMAGE_TAG=24.04
 ARG EASY_INFRA_TAG
 # The following arg is in case we have a {tool}-{environment} specific Dockerfile/frag combo.
 # Dockerfile ARG instructions go out of scope at the end of the build stage where it was defined, so to use it in our multistage scenario it needs to

--- a/easy_infra.yml
+++ b/easy_infra.yml
@@ -53,7 +53,7 @@ packages:
           --libraries-path ${KICS_LIBRARIES_PATH} --report-formats json --output-path
           ${KICS_JSON_REPORT_PATH} --output-name kics --path .
         description: directory scan
-    version: 7.7.0+dfsg-1
+    version: 9.2.0+dfsg-0ubuntu5
     version_argument: --version
   aws-cli:
     aliases:
@@ -72,12 +72,12 @@ packages:
       environments:
       - none
       name: cloudformation
-    version: 2.21.3
+    version: 2.22.22
     version_argument: --version
   azure-cli:
     aliases:
     - az
-    version: 2.66.0-1~jammy
+    version: 2.67.0-1~noble
     version_argument: version
   checkov:
     version: 3.2.300
@@ -95,7 +95,7 @@ packages:
   fluent-bit:
     helper:
     - all
-    version: v3.2.0
+    version: v3.2.3
     version_argument: --version
   kics:
     version: v2.1.3


### PR DESCRIPTION
# Contributor Comments

Ubuntu archived its Mantic repos, which caused failures in image build. This PR updates the base image to Ubuntu 24.04 LTS and brings dependencies up to date.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: [replace this text with permalink URL] 
-->